### PR TITLE
test(updaters): added unit tests for Ruby, Java, and C# updaters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 ### Added
 
 - added Ruby, Java, and C# dependency updaters supporting version upgrades and dependency refresh
+- added unit tests for Ruby, Java, and C# updater version fetchers and repository logic
 
 ## [0.13.0] - 2026-04-03
 

--- a/internal/infrastructure/repositories/csharp/csharp_updater_repository_test.go
+++ b/internal/infrastructure/repositories/csharp/csharp_updater_repository_test.go
@@ -1,0 +1,345 @@
+//go:build unit
+
+package csharp_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rios0rios0/autoupdate/internal/domain/entities"
+	csUpdater "github.com/rios0rios0/autoupdate/internal/infrastructure/repositories/csharp"
+	"github.com/rios0rios0/autoupdate/test/infrastructure/repositorydoubles"
+)
+
+func TestName(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return csharp as updater name", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		updater := csUpdater.NewUpdaterRepository()
+
+		// when
+		name := updater.Name()
+
+		// then
+		assert.Equal(t, "csharp", name)
+	})
+}
+
+func TestDetect(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return true when csproj files exist", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithFiles([]entities.File{{Path: "App.csproj"}}).
+			BuildSpy()
+		repo := entities.Repository{Organization: "org", Name: "repo"}
+
+		// when
+		detected := csUpdater.NewUpdaterRepository().Detect(t.Context(), provider, repo)
+
+		// then
+		assert.True(t, detected)
+	})
+
+	t.Run("should return false when no C# files exist", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithFiles([]entities.File{}).
+			BuildSpy()
+		repo := entities.Repository{Organization: "org", Name: "repo"}
+
+		// when
+		detected := csUpdater.NewUpdaterRepository().Detect(t.Context(), provider, repo)
+
+		// then
+		assert.False(t, detected)
+	})
+}
+
+func TestParseGlobalJSON(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should extract SDK version from valid global.json", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := `{"sdk":{"version":"8.0.11"}}`
+
+		// when
+		result := csUpdater.ParseGlobalJSON(content)
+
+		// then
+		assert.Equal(t, "8.0.11", result)
+	})
+
+	t.Run("should return empty when sdk field is missing", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := `{"tools":{}}`
+
+		// when
+		result := csUpdater.ParseGlobalJSON(content)
+
+		// then
+		assert.Equal(t, "", result)
+	})
+
+	t.Run("should return empty for invalid JSON", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := "{broken"
+
+		// when
+		result := csUpdater.ParseGlobalJSON(content)
+
+		// then
+		assert.Equal(t, "", result)
+	})
+
+	t.Run("should return empty for empty string", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := ""
+
+		// when
+		result := csUpdater.ParseGlobalJSON(content)
+
+		// then
+		assert.Equal(t, "", result)
+	})
+
+	t.Run("should return empty when version is empty string", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := `{"sdk":{"version":""}}`
+
+		// when
+		result := csUpdater.ParseGlobalJSON(content)
+
+		// then
+		assert.Equal(t, "", result)
+	})
+}
+
+func TestResolveVersionContext(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should detect version upgrade needed", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{"global.json": true}).
+			WithFileContents(map[string]string{
+				"global.json": `{"sdk":{"version":"6.0.25"}}`,
+			}).
+			BuildSpy()
+		repo := entities.Repository{Organization: "org", Name: "repo", DefaultBranch: "refs/heads/main"}
+
+		// when
+		vCtx := csUpdater.ResolveVersionContext(t.Context(), provider, repo, "8.0.11")
+
+		// then
+		require.NotNil(t, vCtx)
+		assert.True(t, vCtx.NeedsVersionUpgrade)
+		assert.Contains(t, vCtx.BranchName, "8.0.11")
+	})
+
+	t.Run("should detect deps-only when version is current", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{"global.json": true}).
+			WithFileContents(map[string]string{
+				"global.json": `{"sdk":{"version":"8.0.11"}}`,
+			}).
+			BuildSpy()
+		repo := entities.Repository{Organization: "org", Name: "repo", DefaultBranch: "refs/heads/main"}
+
+		// when
+		vCtx := csUpdater.ResolveVersionContext(t.Context(), provider, repo, "8.0.11")
+
+		// then
+		require.NotNil(t, vCtx)
+		assert.False(t, vCtx.NeedsVersionUpgrade)
+		assert.Contains(t, vCtx.BranchName, "deps")
+	})
+
+	t.Run("should use deps branch when no global.json exists", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{}).
+			BuildSpy()
+		repo := entities.Repository{Organization: "org", Name: "repo", DefaultBranch: "refs/heads/main"}
+
+		// when
+		vCtx := csUpdater.ResolveVersionContext(t.Context(), provider, repo, "8.0.11")
+
+		// then
+		require.NotNil(t, vCtx)
+		assert.False(t, vCtx.NeedsVersionUpgrade)
+		assert.Equal(t, "chore/upgrade-dotnet-deps", vCtx.BranchName)
+	})
+
+	t.Run("should use deps branch when latest version is empty", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{"global.json": true}).
+			WithFileContents(map[string]string{
+				"global.json": `{"sdk":{"version":"6.0.25"}}`,
+			}).
+			BuildSpy()
+		repo := entities.Repository{Organization: "org", Name: "repo", DefaultBranch: "refs/heads/main"}
+
+		// when
+		vCtx := csUpdater.ResolveVersionContext(t.Context(), provider, repo, "")
+
+		// then
+		require.NotNil(t, vCtx)
+		assert.False(t, vCtx.NeedsVersionUpgrade)
+		assert.Equal(t, "chore/upgrade-dotnet-deps", vCtx.BranchName)
+	})
+}
+
+func TestBuildBatchDotnetScript(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should produce a valid bash script with dotnet commands", func(t *testing.T) {
+		t.Parallel()
+
+		// given / when
+		script := csUpdater.BuildBatchDotnetScript()
+
+		// then
+		assert.True(t, strings.HasPrefix(script, "#!/bin/bash\n"))
+		assert.Contains(t, script, "set -euo pipefail")
+		assert.Contains(t, script, "DOTNET_VERSION_UPDATED")
+		assert.Contains(t, script, "dotnet")
+	})
+}
+
+func TestWriteDotnetUpgradeCommands(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should contain jq and python3 fallback chain", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		var sb strings.Builder
+
+		// when
+		csUpdater.WriteDotnetUpgradeCommands(&sb)
+		result := sb.String()
+
+		// then
+		assert.Contains(t, result, "jq")
+		assert.Contains(t, result, "python3")
+		assert.Contains(t, result, "global.json")
+		assert.Contains(t, result, "DOTNET_VERSION_UPDATED")
+	})
+}
+
+func TestGeneratePRDescription(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should include version info when SDK version was updated", func(t *testing.T) {
+		t.Parallel()
+
+		// given / when
+		result := csUpdater.GeneratePRDescription("8.0.11", true)
+
+		// then
+		assert.Contains(t, result, "8.0.11")
+		assert.Contains(t, result, "global.json")
+	})
+
+	t.Run("should describe deps-only update when no version change", func(t *testing.T) {
+		t.Parallel()
+
+		// given / when
+		result := csUpdater.GeneratePRDescription("8.0.11", false)
+
+		// then
+		assert.Contains(t, result, "NuGet")
+	})
+}
+
+func TestWriteGitAuth(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should generate github auth config", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		var sb strings.Builder
+		params := csUpdater.UpgradeParamsExported{
+			ProviderName: "github",
+			AuthToken:    "ghp_token",
+		}
+
+		// when
+		csUpdater.WriteGitAuth(&sb, params)
+
+		// then
+		result := sb.String()
+		assert.Contains(t, result, "x-access-token")
+		assert.Contains(t, result, "github.com")
+	})
+
+	t.Run("should generate azuredevops auth config", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		var sb strings.Builder
+		params := csUpdater.UpgradeParamsExported{
+			ProviderName: "azuredevops",
+			AuthToken:    "ado_pat",
+		}
+
+		// when
+		csUpdater.WriteGitAuth(&sb, params)
+
+		// then
+		result := sb.String()
+		assert.Contains(t, result, "dev.azure.com")
+	})
+
+	t.Run("should generate gitlab auth config", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		var sb strings.Builder
+		params := csUpdater.UpgradeParamsExported{
+			ProviderName: "gitlab",
+			AuthToken:    "gl_token",
+		}
+
+		// when
+		csUpdater.WriteGitAuth(&sb, params)
+
+		// then
+		result := sb.String()
+		assert.Contains(t, result, "oauth2")
+		assert.Contains(t, result, "gitlab.com")
+	})
+}

--- a/internal/infrastructure/repositories/csharp/version_fetcher_test.go
+++ b/internal/infrastructure/repositories/csharp/version_fetcher_test.go
@@ -1,0 +1,293 @@
+//go:build unit
+
+package csharp_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	csUpdater "github.com/rios0rios0/autoupdate/internal/infrastructure/repositories/csharp"
+)
+
+func TestHTTPDotnetVersionFetcher(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return latest active .NET version when API responds with valid data", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			releases := []map[string]any{
+				{"cycle": "8.0", "latest": "8.0.11", "eol": false},
+				{"cycle": "6.0", "latest": "6.0.36", "eol": false},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(releases)
+		}))
+		defer server.Close()
+		fetcher := csUpdater.NewHTTPDotnetVersionFetcherWithURL(server.Client(), server.URL)
+
+		// when
+		version, err := fetcher.FetchLatestVersion(t.Context())
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "8.0.11", version)
+	})
+
+	t.Run("should skip EOL releases and return first active version", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			releases := []map[string]any{
+				{"cycle": "6.0", "latest": "6.0.36", "eol": true},
+				{"cycle": "8.0", "latest": "8.0.11", "eol": false},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(releases)
+		}))
+		defer server.Close()
+		fetcher := csUpdater.NewHTTPDotnetVersionFetcherWithURL(server.Client(), server.URL)
+
+		// when
+		version, err := fetcher.FetchLatestVersion(t.Context())
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "8.0.11", version)
+	})
+
+	t.Run("should handle EOL as a future date string and treat as active", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		futureDate := time.Now().AddDate(2, 0, 0).Format("2006-01-02")
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			releases := []map[string]any{
+				{"cycle": "8.0", "latest": "8.0.11", "eol": futureDate},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(releases)
+		}))
+		defer server.Close()
+		fetcher := csUpdater.NewHTTPDotnetVersionFetcherWithURL(server.Client(), server.URL)
+
+		// when
+		version, err := fetcher.FetchLatestVersion(t.Context())
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "8.0.11", version)
+	})
+
+	t.Run("should skip release with past EOL date string", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		pastDate := time.Now().AddDate(-1, 0, 0).Format("2006-01-02")
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			releases := []map[string]any{
+				{"cycle": "6.0", "latest": "6.0.36", "eol": pastDate},
+				{"cycle": "8.0", "latest": "8.0.11", "eol": false},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(releases)
+		}))
+		defer server.Close()
+		fetcher := csUpdater.NewHTTPDotnetVersionFetcherWithURL(server.Client(), server.URL)
+
+		// when
+		version, err := fetcher.FetchLatestVersion(t.Context())
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "8.0.11", version)
+	})
+
+	t.Run("should return error when no active release is found", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			releases := []map[string]any{
+				{"cycle": "6.0", "latest": "6.0.36", "eol": true},
+				{"cycle": "5.0", "latest": "5.0.17", "eol": true},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(releases)
+		}))
+		defer server.Close()
+		fetcher := csUpdater.NewHTTPDotnetVersionFetcherWithURL(server.Client(), server.URL)
+
+		// when
+		version, err := fetcher.FetchLatestVersion(t.Context())
+
+		// then
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no active .NET release found")
+		assert.Empty(t, version)
+	})
+
+	t.Run("should return error when server responds with non-200 status", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer server.Close()
+		fetcher := csUpdater.NewHTTPDotnetVersionFetcherWithURL(server.Client(), server.URL)
+
+		// when
+		version, err := fetcher.FetchLatestVersion(t.Context())
+
+		// then
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected status code: 503")
+		assert.Empty(t, version)
+	})
+
+	t.Run("should return error when response body contains malformed JSON", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("{broken"))
+		}))
+		defer server.Close()
+		fetcher := csUpdater.NewHTTPDotnetVersionFetcherWithURL(server.Client(), server.URL)
+
+		// when
+		version, err := fetcher.FetchLatestVersion(t.Context())
+
+		// then
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse .NET versions")
+		assert.Empty(t, version)
+	})
+
+	t.Run("should return error when server is unreachable", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		fetcher := csUpdater.NewHTTPDotnetVersionFetcherWithURL(http.DefaultClient, "http://127.0.0.1:0/nonexistent")
+
+		// when
+		version, err := fetcher.FetchLatestVersion(t.Context())
+
+		// then
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to fetch .NET versions")
+		assert.Empty(t, version)
+	})
+
+	t.Run("should return error when release list is empty", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+		}))
+		defer server.Close()
+		fetcher := csUpdater.NewHTTPDotnetVersionFetcherWithURL(server.Client(), server.URL)
+
+		// when
+		version, err := fetcher.FetchLatestVersion(t.Context())
+
+		// then
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no active .NET release found")
+		assert.Empty(t, version)
+	})
+}
+
+func TestIsActiveRelease(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return true when EOL is false", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		release := csUpdater.DotnetRelease{Cycle: "8.0", Latest: "8.0.11", EOL: false}
+
+		// when
+		result := csUpdater.IsActiveRelease(release)
+
+		// then
+		assert.True(t, result)
+	})
+
+	t.Run("should return false when EOL is true", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		release := csUpdater.DotnetRelease{Cycle: "6.0", Latest: "6.0.36", EOL: true}
+
+		// when
+		result := csUpdater.IsActiveRelease(release)
+
+		// then
+		assert.False(t, result)
+	})
+
+	t.Run("should return false when EOL is a past date string", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		release := csUpdater.DotnetRelease{Cycle: "5.0", Latest: "5.0.17", EOL: "2021-03-31"}
+
+		// when
+		result := csUpdater.IsActiveRelease(release)
+
+		// then
+		assert.False(t, result)
+	})
+
+	t.Run("should return true when EOL is a future date string", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		release := csUpdater.DotnetRelease{Cycle: "8.0", Latest: "8.0.11", EOL: "2028-03-31"}
+
+		// when
+		result := csUpdater.IsActiveRelease(release)
+
+		// then
+		assert.True(t, result)
+	})
+
+	t.Run("should return false when EOL is an invalid date string", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		release := csUpdater.DotnetRelease{Cycle: "7.0", Latest: "7.0.20", EOL: "not-a-date"}
+
+		// when
+		result := csUpdater.IsActiveRelease(release)
+
+		// then
+		assert.False(t, result)
+	})
+
+	t.Run("should return false when EOL is an unexpected type", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		release := csUpdater.DotnetRelease{Cycle: "7.0", Latest: "7.0.20", EOL: 42}
+
+		// when
+		result := csUpdater.IsActiveRelease(release)
+
+		// then
+		assert.False(t, result)
+	})
+}

--- a/internal/infrastructure/repositories/java/java_updater_repository_test.go
+++ b/internal/infrastructure/repositories/java/java_updater_repository_test.go
@@ -1,0 +1,441 @@
+//go:build unit
+
+package java_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rios0rios0/autoupdate/internal/domain/entities"
+	javaUpdater "github.com/rios0rios0/autoupdate/internal/infrastructure/repositories/java"
+	repositorydoubles "github.com/rios0rios0/autoupdate/test/infrastructure/repositorydoubles"
+)
+
+func TestName(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return java as updater name", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		updater := javaUpdater.NewUpdaterRepository()
+
+		// when
+		name := updater.Name()
+
+		// then
+		assert.Equal(t, "java", name)
+	})
+}
+
+func TestDetect(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return true when build.gradle exists", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{"build.gradle": true}).
+			BuildSpy()
+		repo := entities.Repository{Organization: "org", Name: "repo"}
+
+		// when
+		detected := javaUpdater.NewUpdaterRepository().Detect(t.Context(), provider, repo)
+
+		// then
+		assert.True(t, detected)
+	})
+
+	t.Run("should return true when pom.xml exists", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{"pom.xml": true}).
+			BuildSpy()
+		repo := entities.Repository{Organization: "org", Name: "repo"}
+
+		// when
+		detected := javaUpdater.NewUpdaterRepository().Detect(t.Context(), provider, repo)
+
+		// then
+		assert.True(t, detected)
+	})
+
+	t.Run("should return false when no Java files exist", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{}).
+			BuildSpy()
+		repo := entities.Repository{Organization: "org", Name: "repo"}
+
+		// when
+		detected := javaUpdater.NewUpdaterRepository().Detect(t.Context(), provider, repo)
+
+		// then
+		assert.False(t, detected)
+	})
+}
+
+func TestParseJavaVersionFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should extract version from simple version file", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := "21.0.5\n"
+
+		// when
+		result := javaUpdater.ParseJavaVersionFile(content)
+
+		// then
+		assert.Equal(t, "21.0.5", result)
+	})
+
+	t.Run("should return empty when content is empty", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := ""
+
+		// when
+		result := javaUpdater.ParseJavaVersionFile(content)
+
+		// then
+		assert.Equal(t, "", result)
+	})
+
+	t.Run("should skip comment lines", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := "# Java version\n21.0.5\n"
+
+		// when
+		result := javaUpdater.ParseJavaVersionFile(content)
+
+		// then
+		assert.Equal(t, "21.0.5", result)
+	})
+
+	t.Run("should trim whitespace from version", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := "  21.0.5  \n"
+
+		// when
+		result := javaUpdater.ParseJavaVersionFile(content)
+
+		// then
+		assert.Equal(t, "21.0.5", result)
+	})
+}
+
+func TestExtractMajorVersion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should extract major from full semver", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		version := "21.0.5"
+
+		// when
+		result := javaUpdater.ExtractMajorVersion(version)
+
+		// then
+		assert.Equal(t, "21", result)
+	})
+
+	t.Run("should return version unchanged when no dot present", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		version := "21"
+
+		// when
+		result := javaUpdater.ExtractMajorVersion(version)
+
+		// then
+		assert.Equal(t, "21", result)
+	})
+
+	t.Run("should return empty for empty input", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		version := ""
+
+		// when
+		result := javaUpdater.ExtractMajorVersion(version)
+
+		// then
+		assert.Equal(t, "", result)
+	})
+}
+
+func TestDetectLocalBuildSystem(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should detect gradle when build.gradle exists", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		root := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(root, "build.gradle"), []byte(""), 0o600))
+
+		// when
+		result := javaUpdater.DetectLocalBuildSystem(root)
+
+		// then
+		assert.Equal(t, "gradle", result)
+	})
+
+	t.Run("should detect gradle when build.gradle.kts exists", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		root := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(root, "build.gradle.kts"), []byte(""), 0o600))
+
+		// when
+		result := javaUpdater.DetectLocalBuildSystem(root)
+
+		// then
+		assert.Equal(t, "gradle", result)
+	})
+
+	t.Run("should detect maven when pom.xml exists", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		root := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(root, "pom.xml"), []byte(""), 0o600))
+
+		// when
+		result := javaUpdater.DetectLocalBuildSystem(root)
+
+		// then
+		assert.Equal(t, "maven", result)
+	})
+
+	t.Run("should default to gradle when no build files exist", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		root := t.TempDir()
+
+		// when
+		result := javaUpdater.DetectLocalBuildSystem(root)
+
+		// then
+		assert.Equal(t, "gradle", result)
+	})
+}
+
+func TestResolveVersionContext(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should detect version upgrade needed", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{".java-version": true}).
+			WithFileContents(map[string]string{
+				".java-version": "17.0.9\n",
+			}).
+			BuildSpy()
+		repo := entities.Repository{Organization: "org", Name: "repo", DefaultBranch: "refs/heads/main"}
+
+		// when
+		vCtx := javaUpdater.ResolveVersionContext(t.Context(), provider, repo, "21.0.5")
+
+		// then
+		require.NotNil(t, vCtx)
+		assert.True(t, vCtx.NeedsVersionUpgrade)
+		assert.Equal(t, "chore/upgrade-java-21", vCtx.BranchName)
+	})
+
+	t.Run("should detect deps-only when version is current", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{".java-version": true}).
+			WithFileContents(map[string]string{
+				".java-version": "21.0.5\n",
+			}).
+			BuildSpy()
+		repo := entities.Repository{Organization: "org", Name: "repo", DefaultBranch: "refs/heads/main"}
+
+		// when
+		vCtx := javaUpdater.ResolveVersionContext(t.Context(), provider, repo, "21.0.5")
+
+		// then
+		require.NotNil(t, vCtx)
+		assert.False(t, vCtx.NeedsVersionUpgrade)
+		assert.Equal(t, "chore/upgrade-java-deps", vCtx.BranchName)
+	})
+
+	t.Run("should use deps branch when no java-version file exists", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{}).
+			BuildSpy()
+		repo := entities.Repository{Organization: "org", Name: "repo", DefaultBranch: "refs/heads/main"}
+
+		// when
+		vCtx := javaUpdater.ResolveVersionContext(t.Context(), provider, repo, "21.0.5")
+
+		// then
+		require.NotNil(t, vCtx)
+		assert.Equal(t, "chore/upgrade-java-deps", vCtx.BranchName)
+	})
+
+	t.Run("should use deps branch when latest version is empty", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{".java-version": true}).
+			WithFileContents(map[string]string{
+				".java-version": "17.0.9\n",
+			}).
+			BuildSpy()
+		repo := entities.Repository{Organization: "org", Name: "repo", DefaultBranch: "refs/heads/main"}
+
+		// when
+		vCtx := javaUpdater.ResolveVersionContext(t.Context(), provider, repo, "")
+
+		// then
+		require.NotNil(t, vCtx)
+		assert.Equal(t, "chore/upgrade-java-deps", vCtx.BranchName)
+	})
+}
+
+func TestBuildBatchJavaScript(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should produce gradle variant script", func(t *testing.T) {
+		t.Parallel()
+
+		// given / when
+		script := javaUpdater.BuildBatchJavaScript("gradle")
+
+		// then
+		assert.Contains(t, script, "#!/bin/bash")
+		assert.Contains(t, script, "gradlew")
+		assert.Contains(t, script, "JAVA_VERSION_UPDATED")
+		assert.Contains(t, script, `BUILD_SYSTEM="gradle"`)
+	})
+
+	t.Run("should produce maven variant script", func(t *testing.T) {
+		t.Parallel()
+
+		// given / when
+		script := javaUpdater.BuildBatchJavaScript("maven")
+
+		// then
+		assert.Contains(t, script, "#!/bin/bash")
+		assert.Contains(t, script, "mvn")
+		assert.Contains(t, script, `BUILD_SYSTEM="maven"`)
+	})
+}
+
+func TestGeneratePRDescription(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should include version info for gradle project", func(t *testing.T) {
+		t.Parallel()
+
+		// given / when
+		result := javaUpdater.GeneratePRDescription("21.0.5", "gradle", true)
+
+		// then
+		assert.Contains(t, result, "21.0.5")
+		assert.Contains(t, result, ".java-version")
+	})
+
+	t.Run("should describe deps-only update for maven project", func(t *testing.T) {
+		t.Parallel()
+
+		// given / when
+		result := javaUpdater.GeneratePRDescription("21.0.5", "maven", false)
+
+		// then
+		assert.Contains(t, result, "dependencies")
+	})
+}
+
+func TestWriteGitAuth(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should generate github auth config", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		var sb strings.Builder
+		params := javaUpdater.UpgradeParamsExported{
+			ProviderName: "github",
+			AuthToken:    "test-token",
+		}
+
+		// when
+		javaUpdater.WriteGitAuth(&sb, params)
+
+		// then
+		result := sb.String()
+		assert.Contains(t, result, "x-access-token")
+		assert.Contains(t, result, "github.com")
+	})
+
+	t.Run("should generate azuredevops auth config", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		var sb strings.Builder
+		params := javaUpdater.UpgradeParamsExported{
+			ProviderName: "azuredevops",
+			AuthToken:    "test-token",
+		}
+
+		// when
+		javaUpdater.WriteGitAuth(&sb, params)
+
+		// then
+		result := sb.String()
+		assert.Contains(t, result, "dev.azure.com")
+	})
+
+	t.Run("should generate gitlab auth config", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		var sb strings.Builder
+		params := javaUpdater.UpgradeParamsExported{
+			ProviderName: "gitlab",
+			AuthToken:    "test-token",
+		}
+
+		// when
+		javaUpdater.WriteGitAuth(&sb, params)
+
+		// then
+		result := sb.String()
+		assert.Contains(t, result, "oauth2")
+		assert.Contains(t, result, "gitlab.com")
+	})
+}

--- a/internal/infrastructure/repositories/java/version_fetcher_test.go
+++ b/internal/infrastructure/repositories/java/version_fetcher_test.go
@@ -179,9 +179,14 @@ func TestHTTPJavaVersionFetcher(t *testing.T) {
 		t.Parallel()
 
 		// given
-		fetcher := javaUpdater.NewHTTPJavaVersionFetcherWithURL(
-			http.DefaultClient, "http://127.0.0.1:1",
-		)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		client := server.Client()
+		url := server.URL
+		server.Close()
+
+		fetcher := javaUpdater.NewHTTPJavaVersionFetcherWithURL(client, url)
 
 		// when
 		_, err := fetcher.FetchLatestVersion(context.Background())

--- a/internal/infrastructure/repositories/java/version_fetcher_test.go
+++ b/internal/infrastructure/repositories/java/version_fetcher_test.go
@@ -1,0 +1,365 @@
+//go:build unit
+
+package java_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	javaUpdater "github.com/rios0rios0/autoupdate/internal/infrastructure/repositories/java"
+)
+
+func TestHTTPJavaVersionFetcher(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return latest active LTS Java version when API responds with valid data", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(
+				[]byte(
+					`[{"cycle":"21","latest":"21.0.5","lts":"2023-09-19","eol":false},{"cycle":"17","latest":"17.0.13","lts":"2021-09-14","eol":false}]`,
+				),
+			)
+		}))
+		defer server.Close()
+
+		fetcher := javaUpdater.NewHTTPJavaVersionFetcherWithURL(server.Client(), server.URL)
+
+		// when
+		version, err := fetcher.FetchLatestVersion(context.Background())
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "21.0.5", version)
+	})
+
+	t.Run("should skip non-LTS releases and return first LTS release", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(
+				[]byte(
+					`[{"cycle":"22","latest":"22.0.2","lts":false,"eol":false},{"cycle":"21","latest":"21.0.5","lts":"2023-09-19","eol":false}]`,
+				),
+			)
+		}))
+		defer server.Close()
+
+		fetcher := javaUpdater.NewHTTPJavaVersionFetcherWithURL(server.Client(), server.URL)
+
+		// when
+		version, err := fetcher.FetchLatestVersion(context.Background())
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "21.0.5", version)
+	})
+
+	t.Run("should skip EOL releases even if LTS", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(
+				[]byte(
+					`[{"cycle":"11","latest":"11.0.24","lts":"2018-09-25","eol":true},{"cycle":"21","latest":"21.0.5","lts":"2023-09-19","eol":false}]`,
+				),
+			)
+		}))
+		defer server.Close()
+
+		fetcher := javaUpdater.NewHTTPJavaVersionFetcherWithURL(server.Client(), server.URL)
+
+		// when
+		version, err := fetcher.FetchLatestVersion(context.Background())
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "21.0.5", version)
+	})
+
+	t.Run("should handle EOL as future date string and treat as active", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		futureDate := time.Now().AddDate(2, 0, 0).Format("2006-01-02")
+		body := `[{"cycle":"21","latest":"21.0.5","lts":"2023-09-19","eol":"` + futureDate + `"}]`
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(body))
+		}))
+		defer server.Close()
+
+		fetcher := javaUpdater.NewHTTPJavaVersionFetcherWithURL(server.Client(), server.URL)
+
+		// when
+		version, err := fetcher.FetchLatestVersion(context.Background())
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "21.0.5", version)
+	})
+
+	t.Run("should return error when no active LTS release is found", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(
+				[]byte(
+					`[{"cycle":"22","latest":"22.0.2","lts":false,"eol":false},{"cycle":"11","latest":"11.0.24","lts":"2018-09-25","eol":true}]`,
+				),
+			)
+		}))
+		defer server.Close()
+
+		fetcher := javaUpdater.NewHTTPJavaVersionFetcherWithURL(server.Client(), server.URL)
+
+		// when
+		_, err := fetcher.FetchLatestVersion(context.Background())
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no active LTS Java release found")
+	})
+
+	t.Run("should return error when server responds with non-200 status", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		fetcher := javaUpdater.NewHTTPJavaVersionFetcherWithURL(server.Client(), server.URL)
+
+		// when
+		_, err := fetcher.FetchLatestVersion(context.Background())
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected status code: 500")
+	})
+
+	t.Run("should return error when response body contains malformed JSON", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("{broken"))
+		}))
+		defer server.Close()
+
+		fetcher := javaUpdater.NewHTTPJavaVersionFetcherWithURL(server.Client(), server.URL)
+
+		// when
+		_, err := fetcher.FetchLatestVersion(context.Background())
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse Java versions")
+	})
+
+	t.Run("should return error when server is unreachable", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		fetcher := javaUpdater.NewHTTPJavaVersionFetcherWithURL(
+			http.DefaultClient, "http://127.0.0.1:1",
+		)
+
+		// when
+		_, err := fetcher.FetchLatestVersion(context.Background())
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to fetch Java versions")
+	})
+
+	t.Run("should return error when release list is empty", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("[]"))
+		}))
+		defer server.Close()
+
+		fetcher := javaUpdater.NewHTTPJavaVersionFetcherWithURL(server.Client(), server.URL)
+
+		// when
+		_, err := fetcher.FetchLatestVersion(context.Background())
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no active LTS Java release found")
+	})
+}
+
+func TestIsLTSRelease(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return true when LTS is bool true", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		release := javaUpdater.JavaRelease{LTS: true}
+
+		// when
+		result := javaUpdater.IsLTSRelease(release)
+
+		// then
+		assert.True(t, result)
+	})
+
+	t.Run("should return false when LTS is bool false", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		release := javaUpdater.JavaRelease{LTS: false}
+
+		// when
+		result := javaUpdater.IsLTSRelease(release)
+
+		// then
+		assert.False(t, result)
+	})
+
+	t.Run("should return true when LTS is a non-empty date string", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		release := javaUpdater.JavaRelease{LTS: "2023-09-19"}
+
+		// when
+		result := javaUpdater.IsLTSRelease(release)
+
+		// then
+		assert.True(t, result)
+	})
+
+	t.Run("should return false when LTS is an empty string", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		release := javaUpdater.JavaRelease{LTS: ""}
+
+		// when
+		result := javaUpdater.IsLTSRelease(release)
+
+		// then
+		assert.False(t, result)
+	})
+
+	t.Run("should return false when LTS is an unexpected type", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		release := javaUpdater.JavaRelease{LTS: 42}
+
+		// when
+		result := javaUpdater.IsLTSRelease(release)
+
+		// then
+		assert.False(t, result)
+	})
+}
+
+func TestIsActiveRelease(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return true when EOL is bool false", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		release := javaUpdater.JavaRelease{EOL: false}
+
+		// when
+		result := javaUpdater.IsActiveRelease(release)
+
+		// then
+		assert.True(t, result)
+	})
+
+	t.Run("should return false when EOL is bool true", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		release := javaUpdater.JavaRelease{EOL: true}
+
+		// when
+		result := javaUpdater.IsActiveRelease(release)
+
+		// then
+		assert.False(t, result)
+	})
+
+	t.Run("should return false when EOL is a past date string", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		release := javaUpdater.JavaRelease{EOL: "2020-01-01"}
+
+		// when
+		result := javaUpdater.IsActiveRelease(release)
+
+		// then
+		assert.False(t, result)
+	})
+
+	t.Run("should return true when EOL is a future date string", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		futureDate := time.Now().AddDate(2, 0, 0).Format("2006-01-02")
+		release := javaUpdater.JavaRelease{EOL: futureDate}
+
+		// when
+		result := javaUpdater.IsActiveRelease(release)
+
+		// then
+		assert.True(t, result)
+	})
+
+	t.Run("should return false when EOL is an invalid date string", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		release := javaUpdater.JavaRelease{EOL: "not-a-date"}
+
+		// when
+		result := javaUpdater.IsActiveRelease(release)
+
+		// then
+		assert.False(t, result)
+	})
+
+	t.Run("should return false when EOL is an unexpected type", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		release := javaUpdater.JavaRelease{EOL: 42}
+
+		// when
+		result := javaUpdater.IsActiveRelease(release)
+
+		// then
+		assert.False(t, result)
+	})
+}

--- a/internal/infrastructure/repositories/ruby/ruby_updater_repository_test.go
+++ b/internal/infrastructure/repositories/ruby/ruby_updater_repository_test.go
@@ -1,0 +1,339 @@
+//go:build unit
+
+package ruby_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rios0rios0/autoupdate/internal/domain/entities"
+	rbUpdater "github.com/rios0rios0/autoupdate/internal/infrastructure/repositories/ruby"
+	"github.com/rios0rios0/autoupdate/test/infrastructure/repositorydoubles"
+)
+
+func TestName(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return ruby as updater name", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		updater := rbUpdater.NewUpdaterRepository()
+
+		// when
+		name := updater.Name()
+
+		// then
+		assert.Equal(t, "ruby", name)
+	})
+}
+
+func TestDetect(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return true when Gemfile exists", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{"Gemfile": true}).
+			BuildSpy()
+		repo := entities.Repository{Organization: "org", Name: "repo"}
+
+		// when
+		detected := rbUpdater.NewUpdaterRepository().Detect(t.Context(), provider, repo)
+
+		// then
+		assert.True(t, detected)
+	})
+
+	t.Run("should return false when no Ruby files exist", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{}).
+			BuildSpy()
+		repo := entities.Repository{Organization: "org", Name: "repo"}
+
+		// when
+		detected := rbUpdater.NewUpdaterRepository().Detect(t.Context(), provider, repo)
+
+		// then
+		assert.False(t, detected)
+	})
+}
+
+func TestParseRubyVersionFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should extract version from simple version file", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := "3.3.6\n"
+
+		// when
+		result := rbUpdater.ParseRubyVersionFile(content)
+
+		// then
+		assert.Equal(t, "3.3.6", result)
+	})
+
+	t.Run("should return empty when content is empty", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := ""
+
+		// when
+		result := rbUpdater.ParseRubyVersionFile(content)
+
+		// then
+		assert.Equal(t, "", result)
+	})
+
+	t.Run("should skip comment lines", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := "# comment\n3.3.6\n"
+
+		// when
+		result := rbUpdater.ParseRubyVersionFile(content)
+
+		// then
+		assert.Equal(t, "3.3.6", result)
+	})
+
+	t.Run("should trim whitespace from version", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := "  3.3.6  \n"
+
+		// when
+		result := rbUpdater.ParseRubyVersionFile(content)
+
+		// then
+		assert.Equal(t, "3.3.6", result)
+	})
+}
+
+func TestResolveVersionContext(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should detect version upgrade needed", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{".ruby-version": true}).
+			WithFileContents(map[string]string{
+				".ruby-version": "3.2.0\n",
+			}).
+			BuildSpy()
+		repo := entities.Repository{Organization: "org", Name: "repo", DefaultBranch: "refs/heads/main"}
+
+		// when
+		vCtx := rbUpdater.ResolveVersionContext(t.Context(), provider, repo, "3.3.6")
+
+		// then
+		require.NotNil(t, vCtx)
+		assert.Equal(t, "3.3.6", vCtx.LatestVersion)
+		assert.True(t, vCtx.NeedsVersionUpgrade)
+		assert.Contains(t, vCtx.BranchName, "3.3.6")
+	})
+
+	t.Run("should detect deps-only when version is current", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{".ruby-version": true}).
+			WithFileContents(map[string]string{
+				".ruby-version": "3.3.6\n",
+			}).
+			BuildSpy()
+		repo := entities.Repository{Organization: "org", Name: "repo", DefaultBranch: "refs/heads/main"}
+
+		// when
+		vCtx := rbUpdater.ResolveVersionContext(t.Context(), provider, repo, "3.3.6")
+
+		// then
+		require.NotNil(t, vCtx)
+		assert.False(t, vCtx.NeedsVersionUpgrade)
+		assert.Contains(t, vCtx.BranchName, "deps")
+	})
+
+	t.Run("should use deps branch when no ruby-version file exists", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{}).
+			BuildSpy()
+		repo := entities.Repository{Organization: "org", Name: "repo", DefaultBranch: "refs/heads/main"}
+
+		// when
+		vCtx := rbUpdater.ResolveVersionContext(t.Context(), provider, repo, "3.3.6")
+
+		// then
+		require.NotNil(t, vCtx)
+		assert.False(t, vCtx.NeedsVersionUpgrade)
+		assert.Equal(t, "chore/upgrade-ruby-deps", vCtx.BranchName)
+	})
+
+	t.Run("should use deps branch when latest version is empty", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{".ruby-version": true}).
+			WithFileContents(map[string]string{
+				".ruby-version": "3.2.0\n",
+			}).
+			BuildSpy()
+		repo := entities.Repository{Organization: "org", Name: "repo", DefaultBranch: "refs/heads/main"}
+
+		// when
+		vCtx := rbUpdater.ResolveVersionContext(t.Context(), provider, repo, "")
+
+		// then
+		require.NotNil(t, vCtx)
+		assert.False(t, vCtx.NeedsVersionUpgrade)
+		assert.Equal(t, "chore/upgrade-ruby-deps", vCtx.BranchName)
+	})
+}
+
+func TestGeneratePRDescription(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should include version info when Ruby version was updated", func(t *testing.T) {
+		t.Parallel()
+
+		// given / when
+		result := rbUpdater.GeneratePRDescription("3.3.6", true)
+
+		// then
+		assert.Contains(t, result, "3.3.6")
+		assert.Contains(t, result, ".ruby-version")
+	})
+
+	t.Run("should describe deps-only update when no version change", func(t *testing.T) {
+		t.Parallel()
+
+		// given / when
+		result := rbUpdater.GeneratePRDescription("3.3.6", false)
+
+		// then
+		assert.Contains(t, result, "dependencies")
+	})
+}
+
+func TestBuildBatchRubyScript(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should produce a valid bash script with ruby commands", func(t *testing.T) {
+		t.Parallel()
+
+		// given / when
+		script := rbUpdater.BuildBatchRubyScript()
+
+		// then
+		assert.True(t, strings.HasPrefix(script, "#!/bin/bash\n"))
+		assert.Contains(t, script, "set -euo pipefail")
+		assert.Contains(t, script, "bundle update")
+		assert.Contains(t, script, "RUBY_VERSION_UPDATED")
+	})
+}
+
+func TestBuildUpgradeScript(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should produce valid upgrade script with git operations", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		params := rbUpdater.UpgradeParamsExported{
+			CloneURL:      "https://github.com/org/repo.git",
+			DefaultBranch: "main",
+			BranchName:    "chore/upgrade-ruby-3.3.6",
+			RubyVersion:   "3.3.6",
+			AuthToken:     "token",
+			ProviderName:  "github",
+		}
+
+		// when
+		script := rbUpdater.BuildUpgradeScript(params, "/tmp/repo")
+
+		// then
+		assert.True(t, strings.HasPrefix(script, "#!/bin/bash\n"))
+		assert.Contains(t, script, "git clone")
+		assert.Contains(t, script, "git checkout -b")
+		assert.Contains(t, script, "CHANGES_PUSHED")
+	})
+}
+
+func TestWriteGitAuth(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should generate github auth config", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		var sb strings.Builder
+		params := rbUpdater.UpgradeParamsExported{
+			ProviderName: "github",
+			AuthToken:    "ghp_token",
+		}
+
+		// when
+		rbUpdater.WriteGitAuth(&sb, params)
+
+		// then
+		result := sb.String()
+		assert.Contains(t, result, "x-access-token")
+		assert.Contains(t, result, "github.com")
+	})
+
+	t.Run("should generate azuredevops auth config", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		var sb strings.Builder
+		params := rbUpdater.UpgradeParamsExported{
+			ProviderName: "azuredevops",
+			AuthToken:    "ado_pat",
+		}
+
+		// when
+		rbUpdater.WriteGitAuth(&sb, params)
+
+		// then
+		result := sb.String()
+		assert.Contains(t, result, "dev.azure.com")
+	})
+
+	t.Run("should generate gitlab auth config", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		var sb strings.Builder
+		params := rbUpdater.UpgradeParamsExported{
+			ProviderName: "gitlab",
+			AuthToken:    "gl_token",
+		}
+
+		// when
+		rbUpdater.WriteGitAuth(&sb, params)
+
+		// then
+		result := sb.String()
+		assert.Contains(t, result, "oauth2")
+		assert.Contains(t, result, "gitlab.com")
+	})
+}

--- a/internal/infrastructure/repositories/ruby/version_fetcher_test.go
+++ b/internal/infrastructure/repositories/ruby/version_fetcher_test.go
@@ -1,0 +1,317 @@
+//go:build unit
+
+package ruby_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rbUpdater "github.com/rios0rios0/autoupdate/internal/infrastructure/repositories/ruby"
+)
+
+func TestHTTPRubyVersionFetcher(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return latest active Ruby version when API responds with valid data", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			releases := []map[string]any{
+				{"cycle": "3.3", "latest": "3.3.6", "eol": false},
+				{"cycle": "3.2", "latest": "3.2.6", "eol": false},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(releases)
+		}))
+		defer server.Close()
+		fetcher := rbUpdater.NewHTTPRubyVersionFetcherWithURL(server.Client(), server.URL)
+
+		// when
+		version, err := fetcher.FetchLatestVersion(t.Context())
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "3.3.6", version)
+	})
+
+	t.Run("should skip EOL releases and return first active version", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			releases := []map[string]any{
+				{"cycle": "2.7", "latest": "2.7.8", "eol": true},
+				{"cycle": "3.3", "latest": "3.3.6", "eol": false},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(releases)
+		}))
+		defer server.Close()
+		fetcher := rbUpdater.NewHTTPRubyVersionFetcherWithURL(server.Client(), server.URL)
+
+		// when
+		version, err := fetcher.FetchLatestVersion(t.Context())
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "3.3.6", version)
+	})
+
+	t.Run("should handle EOL as a future date string and treat as active", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		futureDate := time.Now().AddDate(2, 0, 0).Format("2006-01-02")
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			releases := []map[string]any{
+				{"cycle": "3.3", "latest": "3.3.6", "eol": futureDate},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(releases)
+		}))
+		defer server.Close()
+		fetcher := rbUpdater.NewHTTPRubyVersionFetcherWithURL(server.Client(), server.URL)
+
+		// when
+		version, err := fetcher.FetchLatestVersion(t.Context())
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "3.3.6", version)
+	})
+
+	t.Run("should skip release with past EOL date string", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		pastDate := time.Now().AddDate(-1, 0, 0).Format("2006-01-02")
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			releases := []map[string]any{
+				{"cycle": "2.7", "latest": "2.7.8", "eol": pastDate},
+				{"cycle": "3.3", "latest": "3.3.6", "eol": false},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(releases)
+		}))
+		defer server.Close()
+		fetcher := rbUpdater.NewHTTPRubyVersionFetcherWithURL(server.Client(), server.URL)
+
+		// when
+		version, err := fetcher.FetchLatestVersion(t.Context())
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "3.3.6", version)
+	})
+
+	t.Run("should return error when no active release is found", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			releases := []map[string]any{
+				{"cycle": "2.7", "latest": "2.7.8", "eol": true},
+				{"cycle": "2.6", "latest": "2.6.10", "eol": true},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(releases)
+		}))
+		defer server.Close()
+		fetcher := rbUpdater.NewHTTPRubyVersionFetcherWithURL(server.Client(), server.URL)
+
+		// when
+		version, err := fetcher.FetchLatestVersion(t.Context())
+
+		// then
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no active Ruby release found")
+		assert.Empty(t, version)
+	})
+
+	t.Run("should return error when server responds with non-200 status", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer server.Close()
+		fetcher := rbUpdater.NewHTTPRubyVersionFetcherWithURL(server.Client(), server.URL)
+
+		// when
+		version, err := fetcher.FetchLatestVersion(t.Context())
+
+		// then
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected status code: 503")
+		assert.Empty(t, version)
+	})
+
+	t.Run("should return error when response body contains malformed JSON", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("{broken"))
+		}))
+		defer server.Close()
+		fetcher := rbUpdater.NewHTTPRubyVersionFetcherWithURL(server.Client(), server.URL)
+
+		// when
+		version, err := fetcher.FetchLatestVersion(t.Context())
+
+		// then
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse Ruby versions")
+		assert.Empty(t, version)
+	})
+
+	t.Run("should return error when server is unreachable", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		fetcher := rbUpdater.NewHTTPRubyVersionFetcherWithURL(http.DefaultClient, "http://127.0.0.1:0/nonexistent")
+
+		// when
+		version, err := fetcher.FetchLatestVersion(t.Context())
+
+		// then
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to fetch Ruby versions")
+		assert.Empty(t, version)
+	})
+
+	t.Run("should return error when release list is empty", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+		}))
+		defer server.Close()
+		fetcher := rbUpdater.NewHTTPRubyVersionFetcherWithURL(server.Client(), server.URL)
+
+		// when
+		version, err := fetcher.FetchLatestVersion(t.Context())
+
+		// then
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no active Ruby release found")
+		assert.Empty(t, version)
+	})
+}
+
+func TestIsActiveRelease(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return true when EOL is false", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		release := rbUpdater.RubyRelease{
+			Cycle:  "3.3",
+			Latest: "3.3.6",
+			EOL:    false,
+		}
+
+		// when
+		result := rbUpdater.IsActiveRelease(release)
+
+		// then
+		assert.True(t, result)
+	})
+
+	t.Run("should return false when EOL is true", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		release := rbUpdater.RubyRelease{
+			Cycle:  "2.7",
+			Latest: "2.7.8",
+			EOL:    true,
+		}
+
+		// when
+		result := rbUpdater.IsActiveRelease(release)
+
+		// then
+		assert.False(t, result)
+	})
+
+	t.Run("should return false when EOL is a past date string", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		release := rbUpdater.RubyRelease{
+			Cycle:  "2.6",
+			Latest: "2.6.10",
+			EOL:    "2021-03-31",
+		}
+
+		// when
+		result := rbUpdater.IsActiveRelease(release)
+
+		// then
+		assert.False(t, result)
+	})
+
+	t.Run("should return true when EOL is a future date string", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		release := rbUpdater.RubyRelease{
+			Cycle:  "3.3",
+			Latest: "3.3.6",
+			EOL:    "2028-03-31",
+		}
+
+		// when
+		result := rbUpdater.IsActiveRelease(release)
+
+		// then
+		assert.True(t, result)
+	})
+
+	t.Run("should return false when EOL is an invalid date string", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		release := rbUpdater.RubyRelease{
+			Cycle:  "3.1",
+			Latest: "3.1.6",
+			EOL:    "not-a-date",
+		}
+
+		// when
+		result := rbUpdater.IsActiveRelease(release)
+
+		// then
+		assert.False(t, result)
+	})
+
+	t.Run("should return false when EOL is an unexpected type", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		release := rbUpdater.RubyRelease{
+			Cycle:  "3.1",
+			Latest: "3.1.6",
+			EOL:    42,
+		}
+
+		// when
+		result := rbUpdater.IsActiveRelease(release)
+
+		// then
+		assert.False(t, result)
+	})
+}


### PR DESCRIPTION
## Summary

- Added comprehensive unit tests for the Ruby, Java, and C# dependency updaters introduced in #108
- Covers version fetchers (HTTP mocking, EOL handling, error conditions), updater repository logic (parsing, detection, version context resolution, script generation), and Java-specific features (LTS selection, build system detection)
- 6 test files, ~93 test cases total

## Test plan

- [x] `go test -tags unit ./internal/infrastructure/repositories/ruby/...` passes
- [x] `go test -tags unit ./internal/infrastructure/repositories/java/...` passes
- [x] `go test -tags unit ./internal/infrastructure/repositories/csharp/...` passes
- [x] `go build ./...` succeeds
- [x] `goimports` and `golines` formatting verified

🤖 Generated with [Claude Code](https://claude.ai/claude-code)