### PR TITLE
chore(run): consolidated per-repo updater runs into one aggregate pull request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Changed
 
+- changed batch mode (`run` command) to produce one consolidated pull request per repository that bundles changes from every applicable updater into a single `chore/autoupdate-YYYY-MM-DD` branch, commit, and PR, instead of one PR per updater
+- changed `BatchGitContext` to expose `HeadHash`, `RestoreSnapshot`, `AdvanceSnapshot`, and `FlattenToWorktree` so the aggregate pipeline can roll back individual updater failures without discarding earlier successes
 - changed the Go version to `1.26.2` and updated all module dependencies
 
 ## [0.14.0] - 2026-04-14

--- a/internal/domain/commands/export_test.go
+++ b/internal/domain/commands/export_test.go
@@ -2,7 +2,10 @@
 
 package commands
 
-import "github.com/rios0rios0/autoupdate/internal/domain/entities"
+import (
+	"github.com/rios0rios0/autoupdate/internal/domain/entities"
+	"github.com/rios0rios0/autoupdate/internal/domain/repositories"
+)
 
 // ParseRemoteURL exports parseRemoteURL for testing.
 var ParseRemoteURL = parseRemoteURL //nolint:gochecknoglobals // test export
@@ -38,3 +41,47 @@ var DetectDefaultBranch = detectDefaultBranch //nolint:gochecknoglobals // test 
 
 // ParseGitRemote exports parseGitRemote for testing.
 var ParseGitRemote = parseGitRemote //nolint:gochecknoglobals // test export
+
+// AppliedUpdaterResult exports appliedUpdaterResult for testing.
+type AppliedUpdaterResult = appliedUpdaterResult
+
+// NewAppliedUpdaterResult constructs an appliedUpdaterResult fixture for tests.
+func NewAppliedUpdaterResult(
+	name string, result *repositories.LocalUpdateResult,
+) AppliedUpdaterResult {
+	return appliedUpdaterResult{name: name, result: result}
+}
+
+// ApplicableUpdater exports applicableUpdater for testing.
+type ApplicableUpdater = applicableUpdater
+
+// NewApplicableUpdaterForTest constructs an applicableUpdater fixture for tests.
+func NewApplicableUpdaterForTest(
+	updater repositories.UpdaterRepository, opts entities.UpdateOptions,
+) ApplicableUpdater {
+	return applicableUpdater{updater: updater, opts: opts}
+}
+
+// BuildAggregateBranchName exports buildAggregateBranchName for testing.
+var BuildAggregateBranchName = buildAggregateBranchName //nolint:gochecknoglobals // test export
+
+// BuildAggregateCommitMessage exports buildAggregateCommitMessage for testing.
+var BuildAggregateCommitMessage = buildAggregateCommitMessage //nolint:gochecknoglobals // test export
+
+// BuildAggregatePRTitle exports buildAggregatePRTitle for testing.
+var BuildAggregatePRTitle = buildAggregatePRTitle //nolint:gochecknoglobals // test export
+
+// BuildAggregatePRDescription exports buildAggregatePRDescription for testing.
+var BuildAggregatePRDescription = buildAggregatePRDescription //nolint:gochecknoglobals // test export
+
+// AnyAutoComplete exports anyAutoComplete for testing.
+var AnyAutoComplete = anyAutoComplete //nolint:gochecknoglobals // test export
+
+// AllDryRun exports allDryRun for testing.
+var AllDryRun = allDryRun //nolint:gochecknoglobals // test export
+
+// FirstLine exports firstLine for testing.
+var FirstLine = firstLine //nolint:gochecknoglobals // test export
+
+// ResolveAggregateTargetBranch exports resolveAggregateTargetBranch for testing.
+var ResolveAggregateTargetBranch = resolveAggregateTargetBranch //nolint:gochecknoglobals // test export

--- a/internal/domain/commands/run_command.go
+++ b/internal/domain/commands/run_command.go
@@ -3,7 +3,9 @@ package commands
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
+	"time"
 
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	logger "github.com/sirupsen/logrus"
@@ -260,9 +262,18 @@ func (it *RunCommand) collectApplicableUpdaters(
 	return local, legacy
 }
 
-// processLocalUpdaters clones the repository once and runs all local updaters
-// against the clone, handling branch creation, signed commits, push, and PR
-// creation centrally.
+// appliedUpdaterResult pairs the updater name with the result it returned
+// from ApplyUpdates so the synthesis helpers can build a single aggregate
+// commit and PR.
+type appliedUpdaterResult struct {
+	name   string
+	result *repositories.LocalUpdateResult
+}
+
+// processLocalUpdaters clones the repository once and runs every applicable
+// local updater against a single aggregate branch, producing one signed
+// commit and one pull request that bundles all the changes. Per-updater
+// failure isolation is handled via snapshot commits on BatchGitContext.
 func (it *RunCommand) processLocalUpdaters(
 	ctx context.Context,
 	provider repositories.ProviderRepository,
@@ -270,168 +281,335 @@ func (it *RunCommand) processLocalUpdaters(
 	settings *entities.Settings,
 	updaters []applicableUpdater,
 ) ([]entities.PullRequest, int) {
+	if allDryRun(updaters) {
+		logAggregateDryRun(updaters, repo)
+		return nil, 0
+	}
+
 	cloneURL := provider.CloneURL(repo)
 	defaultBranch := strings.TrimPrefix(repo.DefaultBranch, "refs/heads/")
 
-	// Resolve service type and collect auth methods for clone and push
 	serviceType := gitlocal.ResolveServiceTypeFromURL(it.providerRegistry, cloneURL)
 	authMethods := gitlocal.CollectBatchAuthMethods(
 		it.providerRegistry, serviceType, provider.AuthToken(), settings,
 	)
 
 	gitOps := gitops.NewGitOperations(it.providerRegistry)
-	batchCtx, err := gitlocal.CloneRepository(gitOps, cloneURL, defaultBranch, authMethods, it.providerRegistry)
+	batchCtx, err := gitlocal.CloneRepository(
+		gitOps, cloneURL, defaultBranch, authMethods, it.providerRegistry,
+	)
 	if err != nil {
-		logger.Errorf(
-			"Failed to clone %s/%s: %v", repo.Organization, repo.Name, err,
-		)
-		return nil, len(updaters)
+		logger.Errorf("Failed to clone %s/%s: %v", repo.Organization, repo.Name, err)
+		return nil, 1
 	}
 	defer batchCtx.Close()
 
-	var allPRs []entities.PullRequest
+	aggregateBranch := buildAggregateBranchName(time.Now())
+
+	exists, checkErr := provider.PullRequestExists(ctx, repo, aggregateBranch)
+	if checkErr != nil {
+		logger.Warnf("[autoupdate] Failed to check existing PRs for %s/%s: %v",
+			repo.Organization, repo.Name, checkErr)
+	} else if exists {
+		logger.Infof("[autoupdate] PR already exists for %s/%s on branch %q, skipping",
+			repo.Organization, repo.Name, aggregateBranch)
+		return nil, 0
+	}
+
+	if branchErr := batchCtx.CreateBranchFromDefault(aggregateBranch); branchErr != nil {
+		logger.Errorf("[autoupdate] Failed to create branch %s for %s/%s: %v",
+			aggregateBranch, repo.Organization, repo.Name, branchErr)
+		return nil, 1
+	}
+
+	applied, errorCount := it.runUpdatersOnBranch(ctx, batchCtx, updaters, provider, repo)
+	if len(applied) == 0 {
+		logger.Infof("[autoupdate] %s/%s: no updaters produced changes",
+			repo.Organization, repo.Name)
+		return nil, errorCount
+	}
+
+	pr, pushErrs := it.commitPushAndOpenPR(
+		ctx, batchCtx, provider, repo, settings, authMethods,
+		aggregateBranch, applied, updaters,
+	)
+	if pr == nil {
+		return nil, errorCount + pushErrs
+	}
+	return []entities.PullRequest{*pr}, errorCount + pushErrs
+}
+
+// runUpdatersOnBranch runs each applicable LocalUpdater against the shared
+// worktree on the aggregate branch with snapshot-based failure isolation.
+// On success with real changes, the snapshot advances so the next updater
+// builds on top of it. On failure, the worktree hard-resets to the last
+// known-good snapshot, discarding only the failing updater's partial writes.
+func (it *RunCommand) runUpdatersOnBranch(
+	ctx context.Context,
+	batchCtx *gitlocal.BatchGitContext,
+	updaters []applicableUpdater,
+	provider repositories.ProviderRepository,
+	repo entities.Repository,
+) ([]appliedUpdaterResult, int) {
+	snapshot, err := batchCtx.HeadHash()
+	if err != nil {
+		logger.Errorf("[autoupdate] Failed to resolve HEAD for %s/%s: %v",
+			repo.Organization, repo.Name, err)
+		return nil, 1
+	}
+
+	var applied []appliedUpdaterResult
 	errorCount := 0
 
 	for _, au := range updaters {
+		name := au.updater.Name()
 		lu := au.updater.(repositories.LocalUpdater) //nolint:errcheck,forcetypeassert // checked at partition time
-		prs, errs := it.runLocalUpdater(ctx, batchCtx, lu, au, provider, repo, settings, authMethods)
-		allPRs = append(allPRs, prs...)
-		errorCount += errs
+
+		if au.opts.DryRun {
+			logger.Infof("[%s] [DRY RUN] Would apply updates to %s/%s via aggregate pipeline",
+				name, repo.Organization, repo.Name)
+			continue
+		}
+
+		result, applyErr := lu.ApplyUpdates(ctx, batchCtx.RepoDir(), provider, repo, au.opts)
+		if applyErr != nil {
+			if errors.Is(applyErr, repositories.ErrNoUpdatesNeeded) {
+				logger.Infof("[%s] %s/%s: already up to date",
+					name, repo.Organization, repo.Name)
+				continue
+			}
+			logger.Errorf("[%s] Failed to apply updates to %s/%s: %v",
+				name, repo.Organization, repo.Name, applyErr)
+			errorCount++
+			if rbErr := batchCtx.RestoreSnapshot(snapshot); rbErr != nil {
+				logger.Warnf("[%s] Failed to restore snapshot after failure: %v", name, rbErr)
+			}
+			continue
+		}
+
+		if result == nil {
+			continue
+		}
+
+		applied = append(applied, appliedUpdaterResult{name: name, result: result})
+		logger.Infof("[%s] %s/%s: staged changes for aggregate PR",
+			name, repo.Organization, repo.Name)
+
+		hasChanges, hcErr := batchCtx.HasChanges()
+		if hcErr != nil {
+			logger.Warnf("[%s] Failed to detect changes after apply: %v", name, hcErr)
+			continue
+		}
+		if !hasChanges {
+			continue
+		}
+
+		newSnap, snapErr := batchCtx.AdvanceSnapshot(snapshot)
+		if snapErr != nil {
+			logger.Warnf("[%s] Failed to advance snapshot: %v", name, snapErr)
+			continue
+		}
+		snapshot = newSnap
 	}
 
-	return allPRs, errorCount
+	return applied, errorCount
 }
 
-// resetWorktree resets the batch context to the default branch, logging any error.
-func resetWorktree(batchCtx *gitlocal.BatchGitContext, name string) {
-	if resetErr := batchCtx.ResetToDefault(); resetErr != nil {
-		logger.Warnf("[%s] Failed to reset worktree to default branch: %v", name, resetErr)
-	}
-}
-
-// runLocalUpdater executes a single local updater against the cloned repo.
-func (it *RunCommand) runLocalUpdater(
+// commitPushAndOpenPR flattens the snapshot chain back into the worktree,
+// builds the aggregate commit/PR text, signs and pushes the single commit,
+// and opens the consolidated pull request.
+func (it *RunCommand) commitPushAndOpenPR(
 	ctx context.Context,
 	batchCtx *gitlocal.BatchGitContext,
-	lu repositories.LocalUpdater,
-	au applicableUpdater,
 	provider repositories.ProviderRepository,
 	repo entities.Repository,
 	settings *entities.Settings,
 	authMethods []transport.AuthMethod,
-) ([]entities.PullRequest, int) {
-	name := au.updater.Name()
-
-	if au.opts.DryRun {
-		logger.Infof("[%s] [DRY RUN] Would apply updates to %s/%s via clone-based pipeline",
-			name, repo.Organization, repo.Name)
-		return nil, 0
-	}
-
-	result, err := lu.ApplyUpdates(ctx, batchCtx.RepoDir(), provider, repo, au.opts)
-	if err != nil {
-		if errors.Is(err, repositories.ErrNoUpdatesNeeded) {
-			logger.Infof("[%s] %s/%s: already up to date", name, repo.Organization, repo.Name)
-			return nil, 0
-		}
-		logger.Errorf("[%s] Failed to apply updates to %s/%s: %v",
-			name, repo.Organization, repo.Name, err)
-		resetWorktree(batchCtx, name)
+	branchName string,
+	applied []appliedUpdaterResult,
+	updaters []applicableUpdater,
+) (*entities.PullRequest, int) {
+	if flattenErr := batchCtx.FlattenToWorktree(); flattenErr != nil {
+		logger.Errorf("[autoupdate] Failed to flatten worktree for %s/%s: %v",
+			repo.Organization, repo.Name, flattenErr)
 		return nil, 1
 	}
 
-	exists, prCheckErr := provider.PullRequestExists(ctx, repo, result.BranchName)
-	if prCheckErr != nil {
-		logger.Warnf("[%s] Failed to check existing PRs: %v", name, prCheckErr)
-	}
-	if exists {
-		logger.Infof("[%s] PR already exists for branch %q, skipping", name, result.BranchName)
-		resetWorktree(batchCtx, name)
-		return nil, 0
-	}
+	commitMsg := buildAggregateCommitMessage(applied)
 
-	// CreateBranchFromDefault uses a force-checkout (go-git) which discards
-	// uncommitted working-tree changes.  The upgrade script already modified
-	// go.mod/go.sum on the default branch, so we must stash those changes
-	// before the branch switch and pop them on the new branch.
-	logger.Infof("[%s] Stashing upgrade changes before branch switch to %s", name, result.BranchName)
-	stashed, stashErr := batchCtx.StashChanges()
-	if stashErr != nil {
-		logger.Errorf("[%s] Failed to stash changes before branch switch: %v", name, stashErr)
-		resetWorktree(batchCtx, name)
-		return nil, 1
-	}
-
-	if branchErr := batchCtx.CreateBranchFromDefault(result.BranchName); branchErr != nil {
-		logger.Errorf("[%s] Failed to create branch %s: %v", name, result.BranchName, branchErr)
-		if stashed {
-			batchCtx.DropStash()
-		}
-		resetWorktree(batchCtx, name)
-		return nil, 1
-	}
-
-	if stashed {
-		logger.Infof("[%s] Restoring upgrade changes on branch %s", name, result.BranchName)
-		if popErr := batchCtx.PopStash(); popErr != nil {
-			logger.Errorf("[%s] Failed to pop stash after branch switch: %v", name, popErr)
-			resetWorktree(batchCtx, name)
-			return nil, 1
-		}
-	}
-
-	pushed, pushErr := batchCtx.CommitSignedAndPush(result.BranchName, result.CommitMessage, settings, authMethods)
+	pushed, pushErr := batchCtx.CommitSignedAndPush(branchName, commitMsg, settings, authMethods)
 	if pushErr != nil {
-		logger.Errorf("[%s] Failed to commit/push for %s/%s: %v",
-			name, repo.Organization, repo.Name, pushErr)
-		resetWorktree(batchCtx, name)
+		logger.Errorf("[autoupdate] Failed to commit/push for %s/%s: %v",
+			repo.Organization, repo.Name, pushErr)
 		return nil, 1
 	}
-
 	if !pushed {
-		logger.Infof("[%s] %s/%s: no changes after apply", name, repo.Organization, repo.Name)
-		resetWorktree(batchCtx, name)
+		logger.Infof("[autoupdate] %s/%s: no net changes after apply, skipping PR",
+			repo.Organization, repo.Name)
 		return nil, 0
-	}
-
-	return it.createLocalPR(ctx, batchCtx, au, provider, repo, result, name)
-}
-
-// createLocalPR creates a pull request for changes pushed by a local updater.
-func (it *RunCommand) createLocalPR(
-	ctx context.Context,
-	batchCtx *gitlocal.BatchGitContext,
-	au applicableUpdater,
-	provider repositories.ProviderRepository,
-	repo entities.Repository,
-	result *repositories.LocalUpdateResult,
-	name string,
-) ([]entities.PullRequest, int) {
-	targetBranch := repo.DefaultBranch
-	if au.opts.TargetBranch != "" {
-		targetBranch = "refs/heads/" + au.opts.TargetBranch
 	}
 
 	pr, createErr := provider.CreatePullRequest(ctx, repo, entities.PullRequestInput{
-		SourceBranch: "refs/heads/" + result.BranchName,
-		TargetBranch: targetBranch,
-		Title:        result.PRTitle,
-		Description:  result.PRDescription,
-		AutoComplete: au.opts.AutoComplete,
+		SourceBranch: "refs/heads/" + branchName,
+		TargetBranch: resolveAggregateTargetBranch(repo, updaters),
+		Title:        buildAggregatePRTitle(applied),
+		Description:  buildAggregatePRDescription(applied),
+		AutoComplete: anyAutoComplete(updaters),
 	})
 	if createErr != nil {
-		logger.Errorf("[%s] Failed to create PR for %s/%s: %v",
-			name, repo.Organization, repo.Name, createErr)
-		resetWorktree(batchCtx, name)
+		logger.Errorf("[autoupdate] Failed to create PR for %s/%s: %v",
+			repo.Organization, repo.Name, createErr)
 		return nil, 1
 	}
 
-	logger.Infof("[%s] Created PR #%d for %s/%s: %s",
-		name, pr.ID, repo.Organization, repo.Name, pr.URL)
+	logger.Infof("[autoupdate] Created PR #%d for %s/%s: %s",
+		pr.ID, repo.Organization, repo.Name, pr.URL)
 
 	if switchErr := batchCtx.SwitchToDefault(); switchErr != nil {
-		logger.Warnf("[%s] Failed to switch back to default branch: %v", name, switchErr)
+		logger.Warnf("[autoupdate] Failed to switch back to default branch: %v", switchErr)
 	}
 
-	return []entities.PullRequest{*pr}, 0
+	return pr, 0
+}
+
+// aggregateBranchPrefix is the prefix used for every consolidated branch
+// name produced by the aggregate pipeline. The full name is
+// `chore/autoupdate-YYYY-MM-DD` (UTC), making same-day re-runs idempotent
+// without force-pushing over an under-review pull request.
+const aggregateBranchPrefix = "chore/autoupdate-"
+
+// buildAggregateBranchName returns the deterministic consolidated branch
+// name for a given run timestamp. Two invocations on the same UTC day for
+// the same repo land on the same branch, which together with the
+// PullRequestExists pre-check makes same-day re-runs idempotent.
+func buildAggregateBranchName(now time.Time) string {
+	return aggregateBranchPrefix + now.UTC().Format("2006-01-02")
+}
+
+// buildAggregateCommitMessage synthesizes a single commit message that
+// covers every updater that produced changes. For a single contributor
+// the message passes through verbatim so the one-PR path is
+// indistinguishable from the pre-refactor single-updater output.
+func buildAggregateCommitMessage(applied []appliedUpdaterResult) string {
+	if len(applied) == 1 {
+		return applied[0].result.CommitMessage
+	}
+
+	var sb strings.Builder
+	sb.WriteString("chore(deps): bumped dependencies via autoupdate\n\n")
+	for _, a := range applied {
+		fmt.Fprintf(&sb, "- [%s] %s\n", a.name, firstLine(a.result.CommitMessage))
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+// buildAggregatePRTitle returns the PR title. For a single updater it is
+// that updater's original title; for multiple it lists the contributing
+// updater names so reviewers can see at a glance which ecosystems moved.
+func buildAggregatePRTitle(applied []appliedUpdaterResult) string {
+	if len(applied) == 1 {
+		return applied[0].result.PRTitle
+	}
+	names := make([]string, 0, len(applied))
+	for _, a := range applied {
+		names = append(names, a.name)
+	}
+	return fmt.Sprintf("chore(deps): bumped dependencies (%s)", strings.Join(names, ", "))
+}
+
+// buildAggregatePRDescription renders the PR body with one section per
+// contributing updater, preserving each updater's original PR description
+// so reviewers see the full context for every change.
+func buildAggregatePRDescription(applied []appliedUpdaterResult) string {
+	if len(applied) == 1 {
+		return applied[0].result.PRDescription
+	}
+
+	var sb strings.Builder
+	sb.WriteString("## Summary\n\n")
+	sb.WriteString(
+		"This pull request bundles updates from multiple autoupdate updaters into a single branch " +
+			"so reviewers see the full set of changes for this repository in one place.\n\n",
+	)
+	sb.WriteString("Contributing updaters:\n\n")
+	for _, a := range applied {
+		fmt.Fprintf(&sb, "- `%s` — %s\n", a.name, firstLine(a.result.PRTitle))
+	}
+	sb.WriteString("\n---\n\n")
+	for _, a := range applied {
+		fmt.Fprintf(&sb, "## %s\n\n", a.name)
+		if a.result.PRDescription != "" {
+			sb.WriteString(a.result.PRDescription)
+			sb.WriteString("\n\n")
+		} else {
+			sb.WriteString("_(no description provided by updater)_\n\n")
+		}
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+// resolveAggregateTargetBranch picks the target branch for the aggregate
+// PR. All enabled updaters should agree (they read the same settings); if
+// any one overrides TargetBranch we honor the first non-empty override
+// for determinism.
+func resolveAggregateTargetBranch(
+	repo entities.Repository, updaters []applicableUpdater,
+) string {
+	for _, au := range updaters {
+		if au.opts.TargetBranch != "" {
+			return "refs/heads/" + au.opts.TargetBranch
+		}
+	}
+	return repo.DefaultBranch
+}
+
+// anyAutoComplete returns true if at least one applicable updater requested
+// auto-complete. The aggregate PR represents the same logical "bump
+// dependencies" change every contributor individually requested, so honoring
+// auto-complete when anyone asks for it preserves their intent.
+func anyAutoComplete(updaters []applicableUpdater) bool {
+	for _, au := range updaters {
+		if au.opts.AutoComplete {
+			return true
+		}
+	}
+	return false
+}
+
+// allDryRun reports whether every applicable updater is running in dry-run
+// mode, in which case the aggregate pipeline can short-circuit before
+// cloning anything.
+func allDryRun(updaters []applicableUpdater) bool {
+	if len(updaters) == 0 {
+		return false
+	}
+	for _, au := range updaters {
+		if !au.opts.DryRun {
+			return false
+		}
+	}
+	return true
+}
+
+// logAggregateDryRun emits the dry-run summary line for an aggregate run
+// where every applicable updater is dry-run.
+func logAggregateDryRun(updaters []applicableUpdater, repo entities.Repository) {
+	names := make([]string, 0, len(updaters))
+	for _, au := range updaters {
+		names = append(names, au.updater.Name())
+	}
+	logger.Infof(
+		"[autoupdate] [DRY RUN] Would apply %d updater(s) to %s/%s: %s",
+		len(updaters), repo.Organization, repo.Name, strings.Join(names, ", "),
+	)
+}
+
+// firstLine returns the first newline-delimited segment of s, or s itself
+// when there is no newline. Used to extract subject lines from multi-line
+// commit messages and PR titles.
+func firstLine(s string) string {
+	if before, _, ok := strings.Cut(s, "\n"); ok {
+		return before
+	}
+	return s
 }

--- a/internal/domain/commands/run_command.go
+++ b/internal/domain/commands/run_command.go
@@ -286,24 +286,8 @@ func (it *RunCommand) processLocalUpdaters(
 		return nil, 0
 	}
 
-	cloneURL := provider.CloneURL(repo)
-	defaultBranch := strings.TrimPrefix(repo.DefaultBranch, "refs/heads/")
-
-	serviceType := gitlocal.ResolveServiceTypeFromURL(it.providerRegistry, cloneURL)
-	authMethods := gitlocal.CollectBatchAuthMethods(
-		it.providerRegistry, serviceType, provider.AuthToken(), settings,
-	)
-
-	gitOps := gitops.NewGitOperations(it.providerRegistry)
-	batchCtx, err := gitlocal.CloneRepository(
-		gitOps, cloneURL, defaultBranch, authMethods, it.providerRegistry,
-	)
-	if err != nil {
-		logger.Errorf("Failed to clone %s/%s: %v", repo.Organization, repo.Name, err)
-		return nil, 1
-	}
-	defer batchCtx.Close()
-
+	// Same-day idempotency: short-circuit before touching git if the aggregate
+	// PR already exists for the target branch on this day.
 	aggregateBranch := buildAggregateBranchName(time.Now())
 
 	exists, checkErr := provider.PullRequestExists(ctx, repo, aggregateBranch)
@@ -315,6 +299,29 @@ func (it *RunCommand) processLocalUpdaters(
 			repo.Organization, repo.Name, aggregateBranch)
 		return nil, 0
 	}
+
+	// The clone base ref and the PR target ref must match so the aggregate
+	// branch is not based on a different ref than the PR targets (which would
+	// produce unexpected diffs and conflicts when TargetBranch is overridden).
+	targetBranch := strings.TrimPrefix(
+		resolveAggregateTargetBranch(repo, updaters), "refs/heads/",
+	)
+
+	cloneURL := provider.CloneURL(repo)
+	serviceType := gitlocal.ResolveServiceTypeFromURL(it.providerRegistry, cloneURL)
+	authMethods := gitlocal.CollectBatchAuthMethods(
+		it.providerRegistry, serviceType, provider.AuthToken(), settings,
+	)
+
+	gitOps := gitops.NewGitOperations(it.providerRegistry)
+	batchCtx, err := gitlocal.CloneRepository(
+		gitOps, cloneURL, targetBranch, authMethods, it.providerRegistry,
+	)
+	if err != nil {
+		logger.Errorf("Failed to clone %s/%s: %v", repo.Organization, repo.Name, err)
+		return nil, 1
+	}
+	defer batchCtx.Close()
 
 	if branchErr := batchCtx.CreateBranchFromDefault(aggregateBranch); branchErr != nil {
 		logger.Errorf("[autoupdate] Failed to create branch %s for %s/%s: %v",
@@ -382,7 +389,16 @@ func (it *RunCommand) runUpdatersOnBranch(
 				name, repo.Organization, repo.Name, applyErr)
 			errorCount++
 			if rbErr := batchCtx.RestoreSnapshot(snapshot); rbErr != nil {
-				logger.Warnf("[%s] Failed to restore snapshot after failure: %v", name, rbErr)
+				// A failed restore leaves the worktree in an unknown state,
+				// so any subsequent updater would be building on top of a
+				// potentially corrupted tree. Abort the repo entirely
+				// instead of silently producing a tainted aggregate PR.
+				logger.Errorf(
+					"[%s] failed to restore snapshot after updater failure for %s/%s: "+
+						"updater error: %v; restore error: %v",
+					name, repo.Organization, repo.Name, applyErr, rbErr,
+				)
+				return nil, errorCount
 			}
 			continue
 		}
@@ -406,8 +422,16 @@ func (it *RunCommand) runUpdatersOnBranch(
 
 		newSnap, snapErr := batchCtx.AdvanceSnapshot(snapshot)
 		if snapErr != nil {
-			logger.Warnf("[%s] Failed to advance snapshot: %v", name, snapErr)
-			continue
+			// If the snapshot fails to advance, a later updater failure
+			// would RestoreSnapshot back to the older hash and discard
+			// this updater's successful changes. Treat the advance
+			// failure as fatal for the repo to preserve correctness.
+			logger.Errorf(
+				"[%s] failed to advance snapshot for %s/%s: %v",
+				name, repo.Organization, repo.Name, snapErr,
+			)
+			errorCount++
+			return nil, errorCount
 		}
 		snapshot = newSnap
 	}

--- a/internal/domain/commands/run_command_test.go
+++ b/internal/domain/commands/run_command_test.go
@@ -5,7 +5,9 @@ package commands_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1600,5 +1602,381 @@ func TestFilterRepositories(t *testing.T) {
 
 		// then
 		assert.Empty(t, result)
+	})
+}
+
+func TestBuildAggregateBranchName(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should produce a chore/autoupdate-YYYY-MM-DD branch in UTC", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		loc, err := time.LoadLocation("America/Toronto")
+		require.NoError(t, err)
+		// 23:30 in Toronto on Apr 15 (UTC-5 in this period before DST quirks
+		// — pick a date safely inside DST so the offset is deterministic).
+		ts := time.Date(2026, time.July, 15, 23, 30, 0, 0, loc)
+
+		// when
+		branch := commands.BuildAggregateBranchName(ts)
+
+		// then
+		// 23:30 EDT (UTC-4) on July 15 → 03:30 UTC on July 16
+		assert.Equal(t, "chore/autoupdate-2026-07-16", branch)
+	})
+
+	t.Run("should produce the same branch for two same-day calls", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		morning := time.Date(2026, time.April, 15, 8, 0, 0, 0, time.UTC)
+		evening := time.Date(2026, time.April, 15, 22, 0, 0, 0, time.UTC)
+
+		// when
+		branchA := commands.BuildAggregateBranchName(morning)
+		branchB := commands.BuildAggregateBranchName(evening)
+
+		// then
+		assert.Equal(t, branchA, branchB)
+		assert.Equal(t, "chore/autoupdate-2026-04-15", branchA)
+	})
+}
+
+func TestBuildAggregateCommitMessage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should pass the single updater message through verbatim", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		applied := []commands.AppliedUpdaterResult{
+			commands.NewAppliedUpdaterResult("golang", &repositories.LocalUpdateResult{
+				CommitMessage: "chore(deps): upgraded Go version to `1.26.2` and updated all dependencies",
+			}),
+		}
+
+		// when
+		msg := commands.BuildAggregateCommitMessage(applied)
+
+		// then
+		assert.Equal(t, "chore(deps): upgraded Go version to `1.26.2` and updated all dependencies", msg)
+	})
+
+	t.Run("should aggregate multi-updater messages with a bullet list of first lines", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		applied := []commands.AppliedUpdaterResult{
+			commands.NewAppliedUpdaterResult("golang", &repositories.LocalUpdateResult{
+				CommitMessage: "chore(deps): upgraded Go version to `1.26.2` and updated all dependencies\n\nbody",
+			}),
+			commands.NewAppliedUpdaterResult("dockerfile", &repositories.LocalUpdateResult{
+				CommitMessage: "chore(deps): upgraded `golang` from `1.26.1-alpine` to `1.26.2-alpine`",
+			}),
+		}
+
+		// when
+		msg := commands.BuildAggregateCommitMessage(applied)
+
+		// then
+		require.True(t, strings.HasPrefix(msg, "chore(deps): bumped dependencies via autoupdate\n\n"))
+		assert.Contains(t, msg, "- [golang] chore(deps): upgraded Go version to `1.26.2` and updated all dependencies")
+		assert.Contains(t, msg, "- [dockerfile] chore(deps): upgraded `golang` from `1.26.1-alpine` to `1.26.2-alpine`")
+		assert.NotContains(t, msg, "body", "only the first line of each source message should be included")
+	})
+}
+
+func TestBuildAggregatePRTitle(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should pass the single updater PR title through verbatim", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		applied := []commands.AppliedUpdaterResult{
+			commands.NewAppliedUpdaterResult("golang", &repositories.LocalUpdateResult{
+				PRTitle: "chore(deps): upgraded Go version to `1.26.2` and updated all dependencies",
+			}),
+		}
+
+		// when
+		title := commands.BuildAggregatePRTitle(applied)
+
+		// then
+		assert.Equal(t, "chore(deps): upgraded Go version to `1.26.2` and updated all dependencies", title)
+	})
+
+	t.Run("should list contributing updater names for multi-updater runs", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		applied := []commands.AppliedUpdaterResult{
+			commands.NewAppliedUpdaterResult("golang", &repositories.LocalUpdateResult{PRTitle: "Go bump"}),
+			commands.NewAppliedUpdaterResult("dockerfile", &repositories.LocalUpdateResult{PRTitle: "Dockerfile bump"}),
+		}
+
+		// when
+		title := commands.BuildAggregatePRTitle(applied)
+
+		// then
+		assert.Equal(t, "chore(deps): bumped dependencies (golang, dockerfile)", title)
+	})
+}
+
+func TestBuildAggregatePRDescription(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should pass the single updater PR description through verbatim", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		applied := []commands.AppliedUpdaterResult{
+			commands.NewAppliedUpdaterResult("golang", &repositories.LocalUpdateResult{
+				PRDescription: "## Summary\n\nGo upgrade.",
+			}),
+		}
+
+		// when
+		desc := commands.BuildAggregatePRDescription(applied)
+
+		// then
+		assert.Equal(t, "## Summary\n\nGo upgrade.", desc)
+	})
+
+	t.Run("should render Summary, contributing list, and per-updater sections", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		applied := []commands.AppliedUpdaterResult{
+			commands.NewAppliedUpdaterResult("golang", &repositories.LocalUpdateResult{
+				PRTitle:       "chore(deps): upgraded Go to `1.26.2`",
+				PRDescription: "go body",
+			}),
+			commands.NewAppliedUpdaterResult("dockerfile", &repositories.LocalUpdateResult{
+				PRTitle:       "chore(deps): upgraded `golang` to `1.26.2-alpine`",
+				PRDescription: "dockerfile body",
+			}),
+		}
+
+		// when
+		desc := commands.BuildAggregatePRDescription(applied)
+
+		// then
+		assert.Contains(t, desc, "## Summary")
+		assert.Contains(t, desc, "Contributing updaters:")
+		assert.Contains(t, desc, "- `golang` — chore(deps): upgraded Go to `1.26.2`")
+		assert.Contains(t, desc, "- `dockerfile` — chore(deps): upgraded `golang` to `1.26.2-alpine`")
+		assert.Contains(t, desc, "## golang")
+		assert.Contains(t, desc, "go body")
+		assert.Contains(t, desc, "## dockerfile")
+		assert.Contains(t, desc, "dockerfile body")
+	})
+
+	t.Run("should use a placeholder when an updater provides no description", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		applied := []commands.AppliedUpdaterResult{
+			commands.NewAppliedUpdaterResult("golang", &repositories.LocalUpdateResult{
+				PRTitle:       "Go bump",
+				PRDescription: "",
+			}),
+			commands.NewAppliedUpdaterResult("dockerfile", &repositories.LocalUpdateResult{
+				PRTitle:       "Dockerfile bump",
+				PRDescription: "real body",
+			}),
+		}
+
+		// when
+		desc := commands.BuildAggregatePRDescription(applied)
+
+		// then
+		assert.Contains(t, desc, "_(no description provided by updater)_")
+		assert.Contains(t, desc, "real body")
+	})
+}
+
+func TestAnyAutoComplete(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return false for an empty updater slice", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		var updaters []commands.ApplicableUpdater
+
+		// when
+		result := commands.AnyAutoComplete(updaters)
+
+		// then
+		assert.False(t, result)
+	})
+
+	t.Run("should return false when no updater requested auto-complete", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		updaters := []commands.ApplicableUpdater{
+			commands.NewApplicableUpdaterForTest(
+				&doubles.DummyUpdaterRepository{},
+				entities.UpdateOptions{AutoComplete: false},
+			),
+			commands.NewApplicableUpdaterForTest(
+				&doubles.DummyUpdaterRepository{},
+				entities.UpdateOptions{AutoComplete: false},
+			),
+		}
+
+		// when
+		result := commands.AnyAutoComplete(updaters)
+
+		// then
+		assert.False(t, result)
+	})
+
+	t.Run("should return true when at least one updater requested auto-complete", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		updaters := []commands.ApplicableUpdater{
+			commands.NewApplicableUpdaterForTest(
+				&doubles.DummyUpdaterRepository{},
+				entities.UpdateOptions{AutoComplete: false},
+			),
+			commands.NewApplicableUpdaterForTest(
+				&doubles.DummyUpdaterRepository{},
+				entities.UpdateOptions{AutoComplete: true},
+			),
+		}
+
+		// when
+		result := commands.AnyAutoComplete(updaters)
+
+		// then
+		assert.True(t, result)
+	})
+}
+
+func TestAllDryRun(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return false for an empty updater slice", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		var updaters []commands.ApplicableUpdater
+
+		// when
+		result := commands.AllDryRun(updaters)
+
+		// then
+		assert.False(t, result)
+	})
+
+	t.Run("should return true when every updater is dry-run", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		updaters := []commands.ApplicableUpdater{
+			commands.NewApplicableUpdaterForTest(
+				&doubles.DummyUpdaterRepository{}, entities.UpdateOptions{DryRun: true}),
+			commands.NewApplicableUpdaterForTest(
+				&doubles.DummyUpdaterRepository{}, entities.UpdateOptions{DryRun: true}),
+		}
+
+		// when
+		result := commands.AllDryRun(updaters)
+
+		// then
+		assert.True(t, result)
+	})
+
+	t.Run("should return false when at least one updater is not dry-run", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		updaters := []commands.ApplicableUpdater{
+			commands.NewApplicableUpdaterForTest(
+				&doubles.DummyUpdaterRepository{}, entities.UpdateOptions{DryRun: true}),
+			commands.NewApplicableUpdaterForTest(
+				&doubles.DummyUpdaterRepository{}, entities.UpdateOptions{DryRun: false}),
+		}
+
+		// when
+		result := commands.AllDryRun(updaters)
+
+		// then
+		assert.False(t, result)
+	})
+}
+
+func TestResolveAggregateTargetBranch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should fall back to the repo default branch when no override is set", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repo := entities.Repository{DefaultBranch: "refs/heads/main"}
+		updaters := []commands.ApplicableUpdater{
+			commands.NewApplicableUpdaterForTest(
+				&doubles.DummyUpdaterRepository{}, entities.UpdateOptions{}),
+		}
+
+		// when
+		target := commands.ResolveAggregateTargetBranch(repo, updaters)
+
+		// then
+		assert.Equal(t, "refs/heads/main", target)
+	})
+
+	t.Run("should honor the first non-empty TargetBranch override", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repo := entities.Repository{DefaultBranch: "refs/heads/main"}
+		updaters := []commands.ApplicableUpdater{
+			commands.NewApplicableUpdaterForTest(
+				&doubles.DummyUpdaterRepository{},
+				entities.UpdateOptions{TargetBranch: "develop"},
+			),
+		}
+
+		// when
+		target := commands.ResolveAggregateTargetBranch(repo, updaters)
+
+		// then
+		assert.Equal(t, "refs/heads/develop", target)
+	})
+}
+
+func TestFirstLine(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return the first newline-delimited segment", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		s := "subject line\nbody line 1\nbody line 2"
+
+		// when
+		result := commands.FirstLine(s)
+
+		// then
+		assert.Equal(t, "subject line", result)
+	})
+
+	t.Run("should return the whole string when there is no newline", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		s := "single line"
+
+		// when
+		result := commands.FirstLine(s)
+
+		// then
+		assert.Equal(t, "single line", result)
 	})
 }

--- a/internal/infrastructure/repositories/gitlocal/batch_git.go
+++ b/internal/infrastructure/repositories/gitlocal/batch_git.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	gitconfig "github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	logger "github.com/sirupsen/logrus"
 
@@ -297,6 +298,94 @@ func (c *BatchGitContext) DropStash() {
 	cmd.Dir = c.tmpDir
 	_ = cmd.Run()
 	c.stashRef = ""
+}
+
+// snapshotCommitSubject is the sentinel subject line used by AdvanceSnapshot
+// for the throw-away commits that materialize per-updater rollback points.
+// These commits never reach the remote: FlattenToWorktree collapses them
+// before CommitSignedAndPush builds the final aggregate commit.
+const snapshotCommitSubject = "__autoupdate_snapshot__"
+
+// HeadHash returns the current HEAD commit hash. The aggregate pipeline
+// uses this to capture a baseline before running each updater so it can
+// roll back only that updater's partial writes if it fails.
+func (c *BatchGitContext) HeadHash() (plumbing.Hash, error) {
+	head, err := c.repo.Head()
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("failed to resolve HEAD: %w", err)
+	}
+	return head.Hash(), nil
+}
+
+// RestoreSnapshot hard-resets the worktree to the given commit without
+// switching branches. This is the rollback primitive for per-updater
+// failure isolation in the aggregate pipeline: after a failing updater
+// leaves the worktree in a half-modified state, callers restore the last
+// known-good snapshot so the next updater starts from the accumulated
+// state of all prior successful updaters.
+func (c *BatchGitContext) RestoreSnapshot(hash plumbing.Hash) error {
+	if err := c.workTree.Reset(&git.ResetOptions{
+		Mode:   git.HardReset,
+		Commit: hash,
+	}); err != nil {
+		return fmt.Errorf("failed to restore snapshot %s: %w", hash.String()[:7], err)
+	}
+	return nil
+}
+
+// AdvanceSnapshot stages all current worktree changes and commits them as
+// a throw-away snapshot on the current branch, returning the new HEAD
+// hash. The commit is intentionally unsigned and carries
+// snapshotCommitSubject so reviewers can recognise it if it ever leaks.
+// FlattenToWorktree collapses these commits before the aggregate pipeline
+// produces the real signed commit, so they never reach the remote.
+//
+// The prev hash is passed in for traceability/logging only; the new
+// commit is created on top of whatever HEAD currently points at.
+func (c *BatchGitContext) AdvanceSnapshot(prev plumbing.Hash) (plumbing.Hash, error) {
+	if err := gitops.StageAll(c.workTree); err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("failed to stage snapshot: %w", err)
+	}
+	commit, err := c.workTree.Commit(snapshotCommitSubject, &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "autoupdate[bot]",
+			Email: "autoupdate[bot]@users.noreply.github.com",
+			When:  time.Now(),
+		},
+	})
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf(
+			"failed to create snapshot commit (prev=%s): %w",
+			prev.String()[:7], err,
+		)
+	}
+	return commit, nil
+}
+
+// FlattenToWorktree collapses any snapshot commits made via AdvanceSnapshot
+// back into the worktree and index, so a subsequent CommitSignedAndPush
+// produces one signed commit representing the full aggregate diff. It
+// works by mixed-resetting the current branch back to the default branch
+// head; nothing has been pushed yet, so rewriting the branch here is safe.
+//
+// MixedReset (rather than SoftReset) is used so the change set lands in
+// both the index and the working tree — CommitSignedAndPush calls
+// HasChanges() / WorktreeIsClean() which inspect the working tree rather
+// than the index, so the diff must be visible there.
+func (c *BatchGitContext) FlattenToWorktree() error {
+	defaultRef, err := c.repo.Reference(
+		plumbing.NewBranchReferenceName(c.defaultBranch), true,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to resolve default branch ref: %w", err)
+	}
+	if resetErr := c.workTree.Reset(&git.ResetOptions{
+		Mode:   git.MixedReset,
+		Commit: defaultRef.Hash(),
+	}); resetErr != nil {
+		return fmt.Errorf("failed to flatten worktree: %w", resetErr)
+	}
+	return nil
 }
 
 // Close removes the temporary directory created during cloning.

--- a/internal/infrastructure/repositories/gitlocal/batch_git_snapshot_test.go
+++ b/internal/infrastructure/repositories/gitlocal/batch_git_snapshot_test.go
@@ -1,0 +1,136 @@
+//go:build unit
+
+package gitlocal_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHeadHash(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return the current HEAD hash after creating an aggregate branch", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repoDir := createTestRepoWithCommit(t)
+		ctx := newBatchGitContext(t, repoDir)
+		require.NoError(t, ctx.CreateBranchFromDefault("chore/autoupdate-2026-04-15"))
+
+		// when
+		hash, err := ctx.HeadHash()
+
+		// then
+		require.NoError(t, err)
+		assert.NotEqual(t, plumbing.ZeroHash, hash)
+	})
+}
+
+func TestRestoreSnapshot(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should hard-reset the worktree to the given hash without losing earlier accumulated changes", func(t *testing.T) {
+		t.Parallel()
+
+		// given — clone, branch, write fileA, advance snapshot, then write fileB on top
+		repoDir := createTestRepoWithCommit(t)
+		ctx := newBatchGitContext(t, repoDir)
+		require.NoError(t, ctx.CreateBranchFromDefault("chore/autoupdate-2026-04-15"))
+
+		baseHash, err := ctx.HeadHash()
+		require.NoError(t, err)
+
+		require.NoError(t, os.WriteFile(filepath.Join(repoDir, "fileA.txt"), []byte("A"), 0o600))
+		snapAfterA, err := ctx.AdvanceSnapshot(baseHash)
+		require.NoError(t, err)
+
+		require.NoError(t, os.WriteFile(filepath.Join(repoDir, "fileB.txt"), []byte("B"), 0o600))
+
+		// when — restore back to the snapshot taken after fileA
+		require.NoError(t, ctx.RestoreSnapshot(snapAfterA))
+
+		// then — fileA is still present (committed into the snapshot), fileB is gone
+		_, statErrA := os.Stat(filepath.Join(repoDir, "fileA.txt"))
+		assert.NoError(t, statErrA, "fileA from a prior accumulated snapshot should be preserved")
+
+		_, statErrB := os.Stat(filepath.Join(repoDir, "fileB.txt"))
+		assert.True(t, os.IsNotExist(statErrB), "fileB from the failed updater should be discarded")
+	})
+}
+
+func TestAdvanceSnapshot(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should produce a new HEAD hash and leave the worktree clean", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repoDir := createTestRepoWithCommit(t)
+		ctx := newBatchGitContext(t, repoDir)
+		require.NoError(t, ctx.CreateBranchFromDefault("chore/autoupdate-2026-04-15"))
+
+		baseHash, err := ctx.HeadHash()
+		require.NoError(t, err)
+
+		require.NoError(t, os.WriteFile(filepath.Join(repoDir, "fileA.txt"), []byte("A"), 0o600))
+
+		// when
+		newHash, advErr := ctx.AdvanceSnapshot(baseHash)
+
+		// then
+		require.NoError(t, advErr)
+		assert.NotEqual(t, plumbing.ZeroHash, newHash)
+		assert.NotEqual(t, baseHash, newHash)
+
+		head, headErr := ctx.HeadHash()
+		require.NoError(t, headErr)
+		assert.Equal(t, newHash, head)
+
+		clean, hcErr := ctx.HasChanges()
+		require.NoError(t, hcErr)
+		assert.False(t, clean, "worktree should be clean after a snapshot commit")
+	})
+}
+
+func TestFlattenToWorktree(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should collapse two snapshot commits back into the worktree as the cumulative diff", func(t *testing.T) {
+		t.Parallel()
+
+		// given — branch from default, accumulate two snapshots
+		repoDir := createTestRepoWithCommit(t)
+		ctx := newBatchGitContext(t, repoDir)
+		require.NoError(t, ctx.CreateBranchFromDefault("chore/autoupdate-2026-04-15"))
+
+		baseHash, err := ctx.HeadHash()
+		require.NoError(t, err)
+
+		require.NoError(t, os.WriteFile(filepath.Join(repoDir, "fileA.txt"), []byte("A"), 0o600))
+		snapA, err := ctx.AdvanceSnapshot(baseHash)
+		require.NoError(t, err)
+
+		require.NoError(t, os.WriteFile(filepath.Join(repoDir, "fileB.txt"), []byte("B"), 0o600))
+		_, err = ctx.AdvanceSnapshot(snapA)
+		require.NoError(t, err)
+
+		// when
+		require.NoError(t, ctx.FlattenToWorktree())
+
+		// then — both files still exist on disk and the worktree reports changes
+		_, statErrA := os.Stat(filepath.Join(repoDir, "fileA.txt"))
+		assert.NoError(t, statErrA)
+		_, statErrB := os.Stat(filepath.Join(repoDir, "fileB.txt"))
+		assert.NoError(t, statErrB)
+
+		hasChanges, hcErr := ctx.HasChanges()
+		require.NoError(t, hcErr)
+		assert.True(t, hasChanges, "after flattening, the cumulative diff should be visible in the worktree")
+	})
+}

--- a/internal/infrastructure/repositories/gitlocal/batch_git_snapshot_test.go
+++ b/internal/infrastructure/repositories/gitlocal/batch_git_snapshot_test.go
@@ -92,9 +92,9 @@ func TestAdvanceSnapshot(t *testing.T) {
 		require.NoError(t, headErr)
 		assert.Equal(t, newHash, head)
 
-		clean, hcErr := ctx.HasChanges()
+		hasChanges, hcErr := ctx.HasChanges()
 		require.NoError(t, hcErr)
-		assert.False(t, clean, "worktree should be clean after a snapshot commit")
+		assert.False(t, hasChanges, "worktree should be clean after a snapshot commit")
 	})
 }
 

--- a/test/infrastructure/repositorydoubles/spy_local_updater_repository.go
+++ b/test/infrastructure/repositorydoubles/spy_local_updater_repository.go
@@ -1,0 +1,75 @@
+//go:build integration || unit || test
+
+package repositorydoubles //nolint:revive,staticcheck // Test package naming follows established project structure
+
+import (
+	"context"
+
+	"github.com/rios0rios0/autoupdate/internal/domain/entities"
+	"github.com/rios0rios0/autoupdate/internal/domain/repositories"
+)
+
+// SpyLocalUpdaterRepository implements both repositories.UpdaterRepository
+// and repositories.LocalUpdater. ApplyUpdateFn is invoked on each call,
+// allowing tests to write files to repoDir, simulate failures, and return
+// custom LocalUpdateResult values.
+type SpyLocalUpdaterRepository struct {
+	// --- identity ---
+	UpdaterName string
+
+	// --- Detect ---
+	DetectResult  bool
+	DetectedRepos []entities.Repository
+
+	// --- ApplyUpdates ---
+	// ApplyUpdateFn receives repoDir and returns what ApplyUpdates should
+	// yield for this invocation. Tests use this to mutate the worktree and
+	// control the result/error.
+	ApplyUpdateFn  func(repoDir string) (*repositories.LocalUpdateResult, error)
+	ApplyCallCount int
+}
+
+var (
+	_ repositories.UpdaterRepository = (*SpyLocalUpdaterRepository)(nil)
+	_ repositories.LocalUpdater      = (*SpyLocalUpdaterRepository)(nil)
+)
+
+// Name returns the configured updater name.
+func (u *SpyLocalUpdaterRepository) Name() string { return u.UpdaterName }
+
+// Detect records the repository and returns the configured result.
+func (u *SpyLocalUpdaterRepository) Detect(
+	_ context.Context, _ repositories.ProviderRepository, repo entities.Repository,
+) bool {
+	u.DetectedRepos = append(u.DetectedRepos, repo)
+	return u.DetectResult
+}
+
+// CreateUpdatePRs is unused — local updaters go through ApplyUpdates in
+// the aggregate pipeline. It is implemented only to satisfy the
+// UpdaterRepository interface.
+func (u *SpyLocalUpdaterRepository) CreateUpdatePRs(
+	_ context.Context,
+	_ repositories.ProviderRepository,
+	_ entities.Repository,
+	_ entities.UpdateOptions,
+) ([]entities.PullRequest, error) {
+	return nil, nil
+}
+
+// ApplyUpdates dispatches to ApplyUpdateFn when set, otherwise reports
+// no updates needed. Tests typically inject ApplyUpdateFn to mutate the
+// worktree and return a fixed LocalUpdateResult.
+func (u *SpyLocalUpdaterRepository) ApplyUpdates(
+	_ context.Context,
+	repoDir string,
+	_ repositories.ProviderRepository,
+	_ entities.Repository,
+	_ entities.UpdateOptions,
+) (*repositories.LocalUpdateResult, error) {
+	u.ApplyCallCount++
+	if u.ApplyUpdateFn != nil {
+		return u.ApplyUpdateFn(repoDir)
+	}
+	return nil, repositories.ErrNoUpdatesNeeded
+}

--- a/test/infrastructure/repositorydoubles/spy_local_updater_repository_builder.go
+++ b/test/infrastructure/repositorydoubles/spy_local_updater_repository_builder.go
@@ -1,0 +1,81 @@
+//go:build integration || unit || test
+
+package repositorydoubles //nolint:revive,staticcheck // Test package naming follows established project structure
+
+import (
+	"github.com/rios0rios0/autoupdate/internal/domain/repositories"
+	testkit "github.com/rios0rios0/testkit/pkg/test"
+)
+
+// SpyLocalUpdaterRepositoryBuilder helps create test SpyLocalUpdaterRepository
+// instances with a fluent interface.
+type SpyLocalUpdaterRepositoryBuilder struct {
+	*testkit.BaseBuilder
+	updaterName   string
+	detectResult  bool
+	applyUpdateFn func(repoDir string) (*repositories.LocalUpdateResult, error)
+}
+
+// NewSpyLocalUpdaterRepositoryBuilder creates a new spy local updater
+// repository builder with sensible defaults.
+func NewSpyLocalUpdaterRepositoryBuilder() *SpyLocalUpdaterRepositoryBuilder {
+	return &SpyLocalUpdaterRepositoryBuilder{
+		BaseBuilder:  testkit.NewBaseBuilder(),
+		updaterName:  "spy-local",
+		detectResult: false,
+	}
+}
+
+// WithUpdaterName sets the updater name.
+func (b *SpyLocalUpdaterRepositoryBuilder) WithUpdaterName(name string) *SpyLocalUpdaterRepositoryBuilder {
+	b.updaterName = name
+	return b
+}
+
+// WithDetectResult sets the result to return from Detect.
+func (b *SpyLocalUpdaterRepositoryBuilder) WithDetectResult(result bool) *SpyLocalUpdaterRepositoryBuilder {
+	b.detectResult = result
+	return b
+}
+
+// WithApplyUpdateFn sets the function invoked from ApplyUpdates. Tests use
+// this to mutate the worktree and return a custom LocalUpdateResult.
+func (b *SpyLocalUpdaterRepositoryBuilder) WithApplyUpdateFn(
+	fn func(repoDir string) (*repositories.LocalUpdateResult, error),
+) *SpyLocalUpdaterRepositoryBuilder {
+	b.applyUpdateFn = fn
+	return b
+}
+
+// Build creates the spy (satisfies testkit.Builder interface).
+func (b *SpyLocalUpdaterRepositoryBuilder) Build() interface{} {
+	return b.BuildSpy()
+}
+
+// BuildSpy creates the SpyLocalUpdaterRepository with a concrete return type.
+func (b *SpyLocalUpdaterRepositoryBuilder) BuildSpy() *SpyLocalUpdaterRepository {
+	return &SpyLocalUpdaterRepository{
+		UpdaterName:   b.updaterName,
+		DetectResult:  b.detectResult,
+		ApplyUpdateFn: b.applyUpdateFn,
+	}
+}
+
+// Reset clears the builder state, allowing it to be reused.
+func (b *SpyLocalUpdaterRepositoryBuilder) Reset() testkit.Builder {
+	b.BaseBuilder.Reset()
+	b.updaterName = "spy-local"
+	b.detectResult = false
+	b.applyUpdateFn = nil
+	return b
+}
+
+// Clone creates a deep copy of the SpyLocalUpdaterRepositoryBuilder.
+func (b *SpyLocalUpdaterRepositoryBuilder) Clone() testkit.Builder {
+	return &SpyLocalUpdaterRepositoryBuilder{
+		BaseBuilder:   b.BaseBuilder.Clone().(*testkit.BaseBuilder),
+		updaterName:   b.updaterName,
+		detectResult:  b.detectResult,
+		applyUpdateFn: b.applyUpdateFn,
+	}
+}


### PR DESCRIPTION
## Summary

- Consolidated the `run` command so each target repository receives a
  single `chore/autoupdate-YYYY-MM-DD` branch with one signed commit
  and one pull request bundling every applicable updater's changes,
  instead of one PR per updater.
- Added snapshot-based per-updater failure isolation on
  `BatchGitContext` so a failing updater only rolls back its own
  partial writes, preserving earlier successes inside the same run.
- Added BDD-style unit tests for the aggregate synthesis helpers and
  the new snapshot primitives. The legacy `CreateUpdatePRs` path is
  untouched.

## Motivation

Running the tool against a Go service that also ships a Dockerfile
produced two conflicting PRs on the same repository, each racing to
edit `CHANGELOG.md` under `[Unreleased]`. Reviewers had to merge them
in strict order or manually rebase. This refactor produces one PR per
repo per day, which matches how humans review dependency bumps.

I hit this concretely while rebasing 21 PRs across Azure DevOps repos
where every repo had two autoupdate PRs fighting over the same
changelog section. After rebasing, ~15 of them degraded to
\"CHANGELOG-only\" redundant PRs because the Dockerfile change was
already present on `main` from the sibling PR — clear evidence the
two PRs were duplicates.

## Branch naming

`chore/autoupdate-YYYY-MM-DD` (UTC). Same-day re-runs short-circuit on
`PullRequestExists` before touching git, so the branch is idempotent
for a day without force-pushing over an under-review PR. New day rolls
to a new branch, opening a fresh PR if anything new surfaced.

## Failure isolation

Before each updater runs, the pipeline captures the current HEAD as a
snapshot. On updater failure, `RestoreSnapshot` hard-resets the
worktree to the last known-good hash, so the next updater starts from
the accumulated state of all prior successful updaters. On success
with real changes, `AdvanceSnapshot` stages and commits the change as
a throw-away snapshot commit. After the loop, `FlattenToWorktree`
mixed-resets back to the default branch so `CommitSignedAndPush`
produces exactly one signed commit covering the union of all
contributions.

The snapshot commits are intentionally unsigned and carry the sentinel
subject \`__autoupdate_snapshot__\` — they exist only inside the temp
clone and are flattened away before the real signed commit is built.

## Aggregate output formats

**Single-updater pass-through:** when only one updater applies, the
helpers return the updater's own \`CommitMessage\` / \`PRTitle\` /
\`PRDescription\` verbatim. The only visible delta vs the previous
behavior is the branch name.

**Multi-updater commit message:**
\`\`\`
chore(deps): bumped dependencies via autoupdate

- [golang] chore(deps): upgraded Go version to \`1.26.2\` and updated all dependencies
- [dockerfile] chore(deps): upgraded \`golang\` from \`1.26.1-alpine\` to \`1.26.2-alpine\`
\`\`\`

**Multi-updater PR title:** \`chore(deps): bumped dependencies (golang, dockerfile)\`

**Multi-updater PR description:** \`## Summary\` + \`Contributing
updaters:\` bullet list + one \`## <name>\` section per contributor
embedding each updater's own \`PRDescription\`.

## Out of scope

- \`local\` command — still uses the per-run flow, not the aggregate
  pipeline. A follow-up PR will align it.
- Parameterizing the branch date format or cadence.

## Test plan

- [x] \`go test ./internal/domain/commands/... -tags=unit\` passes (new
      synthesis helper tests + existing legacy tests)
- [x] \`go test ./internal/infrastructure/repositories/gitlocal/... -tags=unit\`
      passes (new snapshot primitive tests against a local bare-repo
      fixture)
- [x] \`go test ./... -tags=unit\` passes (full unit suite, ~10s total)
- [x] \`make lint\` clean (0 issues, 79 linters)
- [x] \`make sast\` clean (Semgrep 0, Trivy 0; Hadolint skipped — no Dockerfiles)
- [ ] Manual smoke: run \`autoupdate run\` against a Go repo with a
      Dockerfile and verify a single \`chore/autoupdate-<today>\` PR
      lands with both updater sections in the description and one
      signed commit
- [ ] Manual smoke: re-run the same command the same day and verify
      the second run logs \`PR already exists ... skipping\`

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the \`CHANGELOG.md\`?
- [x] Did you run all the code checks? (\`go test\`)
- [x] Are the tests passing?

🤖 Generated with [Claude Code](https://claude.com/claude-code)