### PR TITLE
feat: per-repo .autoupdate.yaml + global exclude_repos

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -119,6 +119,9 @@ Cobra CLI (controllers) -> Commands (domain logic) -> Repositories (ports/adapte
 - Supports multiple providers with organizations and tokens
 - Token resolution: inline values, `${ENV_VAR}` expansion, file paths
 - Updaters can be enabled/disabled with per-updater `auto_complete` and `target_branch`
+- Repository exclusions:
+  - **Global**: `exclude_repos` in user config — right-anchored glob list matched against `<org>/<repo>` (or `<org>/<project>/<repo>` for ADO). Filtered by `filterRepositories` in `RunCommand`; honored in `LocalCommand` when settings load successfully.
+  - **Per-repo**: `.autoupdate.yaml` in the target repository's root with `skip: true` (and optional `reason`). Read via `support.LoadLocalRepoConfig` (local mode) and `support.LoadRemoteRepoConfig` (batch mode, fetched through `FileAccessProvider.GetFileContent`). Remote fetch failures fail open so a flaky API does not silently disable all updates.
 
 ### Commit Signing
 When `commit.gpgsign=true` is set in git config, commits are automatically signed using GPG or SSH (based on `gpg.format`). The signing key is read from `user.signingkey`. GPG passphrase is read from `GPG_PASSPHRASE` env var.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,14 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added per-repository `.autoupdate.yaml` opt-out file (`skip: true` short-circuits both `autoupdate run` and `autoupdate .` before any updater work). The optional `reason` field is logged when the skip fires.
+- added `exclude_repos` to the global `autoupdate.yaml`: a right-anchored glob list (`path.Match` semantics) matched against `<org>/<repo>` for GitHub/GitLab and `<org>/<project>/<repo>` for Azure DevOps. Honored in batch mode and in `autoupdate .` when a config file is loadable.
+
 ### Changed
 
+- changed `LocalCommand` to detect the Git remote before language detection so excluded repos no longer require a supported project layout.
 - changed the Go module dependencies to their latest versions
 
 ## [0.14.7] - 2026-04-29

--- a/README.md
+++ b/README.md
@@ -91,6 +91,17 @@ providers:
     organizations:
       - "my-group"
 
+# Skip specific repos globally without touching each project. Patterns
+# are right-anchored against the canonical key:
+#   - GitHub/GitLab: <org>/<repo>
+#   - Azure DevOps:  <org>/<project>/<repo>
+# Glob wildcards (*, ?, [...]) follow path.Match semantics and do not
+# cross "/". A bare name matches the repo's trailing segment.
+exclude_repos:
+  - 'ZestSecurity/frontend/opensearch-dashboards'  # exact ADO path
+  - '*/oui'                                         # any org or org/project ending in /oui
+  - 'rios0rios0/private-fork'                       # exact GitHub path
+
 # The updaters section is optional. All 6 updaters (terraform, golang,
 # python, javascript, pipeline, dockerfile) are enabled by default.
 # Default config is fetched from GitHub and merged with your overrides.
@@ -101,6 +112,24 @@ updaters:
   python:
     enabled: false
 ```
+
+### Skipping a Single Repository (Per-Repo Opt-Out)
+
+Drop a `.autoupdate.yaml` in the **target repository's root** to opt that
+project out of automated updates without touching the global config:
+
+```yaml
+# .autoupdate.yaml in the target repo
+skip: true
+reason: 'fork of upstream; rebase manually before any update'
+```
+
+The `reason` is optional but is logged when the skip fires, so reviewers
+can tell at a glance why a repo is being passed over. The file is
+honored in both `autoupdate run` (read via the provider API on the
+default branch) and `autoupdate .` (read directly from disk). Use it for
+forks you maintain by hand, frozen branches, or any project where
+automated PRs would create more work than they save.
 
 ### Token Resolution
 

--- a/configs/autoupdate.yaml
+++ b/configs/autoupdate.yaml
@@ -18,6 +18,14 @@ providers:
   #   organizations:
   #     - "my-group"
 
+# Skip specific repositories globally. Patterns are right-anchored
+# against <org>/<repo> (or <org>/<project>/<repo> on Azure DevOps), and
+# support `path.Match`-style globs (`*`, `?`, `[...]`) that do not cross
+# "/". A bare name matches the trailing segment of the key.
+# exclude_repos:
+#   - 'ZestSecurity/frontend/opensearch-dashboards'
+#   - '*/oui'
+
 # All updaters are enabled by default with auto_complete disabled.
 # Users only need to override specific fields; omitted fields keep these defaults.
 # The entire updaters section can be omitted to use all defaults.

--- a/internal/domain/commands/export_test.go
+++ b/internal/domain/commands/export_test.go
@@ -27,6 +27,15 @@ func FilterRepositories(
 	return filterRepositories(repos, settings)
 }
 
+// CheckLocalRepoConfigSkip exports checkLocalRepoConfigSkip for testing.
+var CheckLocalRepoConfigSkip = checkLocalRepoConfigSkip //nolint:gochecknoglobals // test export
+
+// IsExcludedByGlobalList exports isExcludedByGlobalList for testing.
+var IsExcludedByGlobalList = isExcludedByGlobalList //nolint:gochecknoglobals // test export
+
+// IsSkippedByRepoConfig exports isSkippedByRepoConfig for testing.
+var IsSkippedByRepoConfig = isSkippedByRepoConfig //nolint:gochecknoglobals // test export
+
 // RunLocalUpgrade exports runLocalUpgrade for testing.
 var RunLocalUpgrade = runLocalUpgrade //nolint:gochecknoglobals // test export
 

--- a/internal/domain/commands/local_command.go
+++ b/internal/domain/commands/local_command.go
@@ -14,6 +14,7 @@ import (
 	goRepo "github.com/rios0rios0/autoupdate/internal/infrastructure/repositories/golang"
 	jsRepo "github.com/rios0rios0/autoupdate/internal/infrastructure/repositories/javascript"
 	pyRepo "github.com/rios0rios0/autoupdate/internal/infrastructure/repositories/python"
+	"github.com/rios0rios0/autoupdate/internal/support"
 	configHelpers "github.com/rios0rios0/gitforge/pkg/config/domain/helpers"
 	gitInfra "github.com/rios0rios0/gitforge/pkg/git/infrastructure"
 	globalEntities "github.com/rios0rios0/gitforge/pkg/global/domain/entities"
@@ -38,6 +39,10 @@ type LocalOptions struct {
 	DryRun  bool
 	Verbose bool
 	Token   string
+	// Settings is optional. When supplied, the global exclude_repos list
+	// is honored in local mode; missing settings means only the per-repo
+	// .autoupdate.yaml controls whether the update runs.
+	Settings *entities.Settings
 }
 
 // remoteInfo holds the parsed components of a Git remote URL.
@@ -92,6 +97,25 @@ func (it *LocalCommand) Execute(ctx context.Context, opts LocalOptions) error {
 		return fmt.Errorf("invalid path: %w", err)
 	}
 
+	if skipped, skipErr := checkLocalRepoConfigSkip(repoDir); skipErr != nil {
+		return skipErr
+	} else if skipped {
+		return nil
+	}
+
+	// Detect Git provider from remote URL — done early so the global
+	// exclude_repos list can short-circuit before paying the cost of
+	// language detection or any updater work.
+	remote, parseErr := parseGitRemote(ctx, repoDir)
+	if parseErr != nil {
+		return fmt.Errorf("failed to detect git provider: %w", parseErr)
+	}
+	logger.Infof("Detected provider: %s, org: %s, repo: %s", remote.ProviderType, remote.Org, remote.RepoName)
+
+	if isExcludedByGlobalList(opts.Settings, remote) {
+		return nil
+	}
+
 	// Detect project type using langforge's registry
 	langProvider, detectErr := langRegistry.NewDefaultRegistry().Detect(repoDir)
 	if detectErr != nil {
@@ -99,13 +123,6 @@ func (it *LocalCommand) Execute(ctx context.Context, opts LocalOptions) error {
 	}
 	projType := langProvider.Language()
 	logger.Infof("Detected project type: %s", projType)
-
-	// Detect Git provider from remote URL
-	remote, parseErr := parseGitRemote(ctx, repoDir)
-	if parseErr != nil {
-		return fmt.Errorf("failed to detect git provider: %w", parseErr)
-	}
-	logger.Infof("Detected provider: %s, org: %s, repo: %s", remote.ProviderType, remote.Org, remote.RepoName)
 
 	// Resolve auth token
 	token := opts.Token
@@ -406,6 +423,51 @@ func parseRemoteURL(rawURL string) (*remoteInfo, error) {
 		Project:      parsed.Project,
 		RepoName:     parsed.RepoName,
 	}, nil
+}
+
+// checkLocalRepoConfigSkip reads the per-repository .autoupdate.yaml from
+// disk and reports whether the user requested that this project be
+// skipped. A missing file is not an error; a malformed file is, because
+// the user explicitly asked autoupdate to read it and we should surface
+// problems instead of silently running anyway.
+func checkLocalRepoConfigSkip(repoDir string) (bool, error) {
+	cfg, err := support.LoadLocalRepoConfig(repoDir)
+	if err != nil {
+		return false, err
+	}
+	if !cfg.IsSkipped() {
+		return false, nil
+	}
+	if cfg.Reason != "" {
+		logger.Infof("Skipping %s: %s requested skip (%s)",
+			repoDir, entities.RepoConfigFile, cfg.Reason)
+	} else {
+		logger.Infof("Skipping %s: %s requested skip", repoDir, entities.RepoConfigFile)
+	}
+	return true, nil
+}
+
+// isExcludedByGlobalList reports whether the parsed remote matches a
+// pattern in the user's global exclude_repos list. The check is a no-op
+// when no Settings were loaded (i.e. the user invoked local mode without
+// a config file), so per-repo .autoupdate.yaml remains the only source
+// of truth in that case.
+func isExcludedByGlobalList(settings *entities.Settings, remote *remoteInfo) bool {
+	if settings == nil || len(settings.ExcludeRepos) == 0 {
+		return false
+	}
+	repo := entities.Repository{
+		Organization: remote.Org,
+		Project:      remote.Project,
+		Name:         remote.RepoName,
+	}
+	excluded, pattern := settings.IsRepoExcluded(repo)
+	if !excluded {
+		return false
+	}
+	logger.Infof("Skipping %s/%s: matched exclude_repos pattern %q",
+		remote.Org, remote.RepoName, pattern)
+	return true
 }
 
 func detectDefaultBranch(ctx context.Context, repoDir string) (string, error) {

--- a/internal/domain/commands/local_command.go
+++ b/internal/domain/commands/local_command.go
@@ -465,8 +465,8 @@ func isExcludedByGlobalList(settings *entities.Settings, remote *remoteInfo) boo
 	if !excluded {
 		return false
 	}
-	logger.Infof("Skipping %s/%s: matched exclude_repos pattern %q",
-		remote.Org, remote.RepoName, pattern)
+	logger.Infof("Skipping %s: matched exclude_repos pattern %q",
+		entities.RepoKey(repo), pattern)
 	return true
 }
 

--- a/internal/domain/commands/local_command_test.go
+++ b/internal/domain/commands/local_command_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/rios0rios0/autoupdate/internal/domain/commands"
+	"github.com/rios0rios0/autoupdate/internal/domain/entities"
+	infraRepos "github.com/rios0rios0/autoupdate/internal/infrastructure/repositories"
 	globalEntities "github.com/rios0rios0/gitforge/pkg/global/domain/entities"
 	langEntities "github.com/rios0rios0/langforge/pkg/domain/entities"
 )
@@ -481,6 +483,233 @@ func TestParseGitRemote(t *testing.T) {
 		assert.Equal(t, "myorg", info.Org)
 		assert.Equal(t, "myproject", info.Project)
 		assert.Equal(t, "myrepo", info.RepoName)
+	})
+}
+
+func TestCheckLocalRepoConfigSkip(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return false when .autoupdate.yaml does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		dir := t.TempDir()
+
+		// when
+		skipped, err := commands.CheckLocalRepoConfigSkip(dir)
+
+		// then
+		require.NoError(t, err)
+		assert.False(t, skipped)
+	})
+
+	t.Run("should return true when .autoupdate.yaml has skip: true", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, ".autoupdate.yaml"),
+			[]byte("skip: true\nreason: \"fork\"\n"),
+			0o600,
+		))
+
+		// when
+		skipped, err := commands.CheckLocalRepoConfigSkip(dir)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, skipped)
+	})
+
+	t.Run("should return false when .autoupdate.yaml has skip: false", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, ".autoupdate.yaml"),
+			[]byte("skip: false\n"),
+			0o600,
+		))
+
+		// when
+		skipped, err := commands.CheckLocalRepoConfigSkip(dir)
+
+		// then
+		require.NoError(t, err)
+		assert.False(t, skipped)
+	})
+
+	t.Run("should propagate parse errors from malformed YAML", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, ".autoupdate.yaml"),
+			[]byte("skip: : not-yaml"),
+			0o600,
+		))
+
+		// when
+		_, err := commands.CheckLocalRepoConfigSkip(dir)
+
+		// then
+		require.Error(t, err)
+	})
+}
+
+func TestIsExcludedByGlobalList(t *testing.T) {
+	t.Parallel()
+
+	github := &commands.RemoteInfo{Org: "rios0rios0", RepoName: "autoupdate"}
+	ado := &commands.RemoteInfo{Org: "ZestSecurity", Project: "frontend", RepoName: "opensearch-dashboards"}
+
+	t.Run("should return false when settings is nil", func(t *testing.T) {
+		t.Parallel()
+
+		// given/when
+		excluded := commands.IsExcludedByGlobalList(nil, github)
+
+		// then
+		assert.False(t, excluded)
+	})
+
+	t.Run("should return false when ExcludeRepos is empty", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		settings := &entities.Settings{}
+
+		// when
+		excluded := commands.IsExcludedByGlobalList(settings, github)
+
+		// then
+		assert.False(t, excluded)
+	})
+
+	t.Run("should return true for matching org/repo pattern", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		settings := &entities.Settings{ExcludeRepos: []string{"rios0rios0/autoupdate"}}
+
+		// when
+		excluded := commands.IsExcludedByGlobalList(settings, github)
+
+		// then
+		assert.True(t, excluded)
+	})
+
+	t.Run("should match Azure DevOps three-segment paths", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		settings := &entities.Settings{ExcludeRepos: []string{
+			"ZestSecurity/frontend/opensearch-dashboards",
+		}}
+
+		// when
+		excluded := commands.IsExcludedByGlobalList(settings, ado)
+
+		// then
+		assert.True(t, excluded)
+	})
+
+	t.Run("should match plain repo names via substring fallback", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		settings := &entities.Settings{ExcludeRepos: []string{"opensearch-dashboards"}}
+
+		// when
+		excluded := commands.IsExcludedByGlobalList(settings, ado)
+
+		// then
+		assert.True(t, excluded)
+	})
+}
+
+func TestLocalCommandExecute(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should short-circuit when .autoupdate.yaml requests skip", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repoDir := initTestGitRepo(t, "main")
+		runGit(t, repoDir, "remote", "add", "origin", "git@github.com:rios0rios0/autoupdate.git")
+		require.NoError(t, os.WriteFile(
+			filepath.Join(repoDir, ".autoupdate.yaml"),
+			[]byte("skip: true\nreason: \"manually maintained\"\n"),
+			0o600,
+		))
+
+		registry := infraRepos.NewProviderRegistry()
+		cmd := commands.NewLocalCommand(registry)
+
+		// when
+		err := cmd.Execute(context.Background(), commands.LocalOptions{
+			RepoDir: repoDir,
+			DryRun:  true,
+		})
+
+		// then
+		// No git provider was registered and no project files exist; the
+		// only way Execute returns nil here is by short-circuiting via
+		// the .autoupdate.yaml skip check before any of those steps run.
+		require.NoError(t, err)
+	})
+
+	t.Run("should short-circuit when global exclude_repos matches", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repoDir := initTestGitRepo(t, "main")
+		runGit(t, repoDir, "remote", "add", "origin", "git@github.com:rios0rios0/autoupdate.git")
+
+		registry := infraRepos.NewProviderRegistry()
+		cmd := commands.NewLocalCommand(registry)
+
+		settings := &entities.Settings{ExcludeRepos: []string{"rios0rios0/autoupdate"}}
+
+		// when
+		err := cmd.Execute(context.Background(), commands.LocalOptions{
+			RepoDir:  repoDir,
+			DryRun:   true,
+			Settings: settings,
+		})
+
+		// then
+		// langforge would otherwise fail to detect a project type here;
+		// returning nil proves the exclude_repos check fired before
+		// language detection.
+		require.NoError(t, err)
+	})
+
+	t.Run("should propagate parse errors from .autoupdate.yaml", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repoDir := initTestGitRepo(t, "main")
+		require.NoError(t, os.WriteFile(
+			filepath.Join(repoDir, ".autoupdate.yaml"),
+			[]byte("skip: : not-yaml"),
+			0o600,
+		))
+
+		registry := infraRepos.NewProviderRegistry()
+		cmd := commands.NewLocalCommand(registry)
+
+		// when
+		err := cmd.Execute(context.Background(), commands.LocalOptions{
+			RepoDir: repoDir,
+			DryRun:  true,
+		})
+
+		// then
+		require.Error(t, err)
 	})
 }
 

--- a/internal/domain/commands/run_command.go
+++ b/internal/domain/commands/run_command.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rios0rios0/autoupdate/internal/domain/repositories"
 	infraRepos "github.com/rios0rios0/autoupdate/internal/infrastructure/repositories"
 	"github.com/rios0rios0/autoupdate/internal/infrastructure/repositories/gitlocal"
+	"github.com/rios0rios0/autoupdate/internal/support"
 	gitops "github.com/rios0rios0/gitforge/pkg/git/infrastructure"
 )
 
@@ -144,12 +145,13 @@ func (it *RunCommand) processOrganization(
 }
 
 // filterRepositories removes repositories that match the exclusion criteria
-// defined in the settings (e.g. forks, archived repos).
+// defined in the settings (e.g. forks, archived repos, or anything in the
+// global exclude_repos list).
 func filterRepositories(
 	repos []entities.Repository,
 	settings *entities.Settings,
 ) []entities.Repository {
-	if !settings.ExcludeForks && !settings.ExcludeArchived {
+	if !settings.ExcludeForks && !settings.ExcludeArchived && len(settings.ExcludeRepos) == 0 {
 		return repos
 	}
 
@@ -163,9 +165,44 @@ func filterRepositories(
 			logger.Debugf("Skipping archived repo: %s/%s", repo.Organization, repo.Name)
 			continue
 		}
+		if excluded, pattern := settings.IsRepoExcluded(repo); excluded {
+			logger.Infof("Skipping %s/%s: matched exclude_repos pattern %q",
+				repo.Organization, repo.Name, pattern)
+			continue
+		}
 		filtered = append(filtered, repo)
 	}
 	return filtered
+}
+
+// isSkippedByRepoConfig reads the target repository's .autoupdate.yaml
+// via the provider API. It returns true only when the file exists and
+// requests an explicit skip; transient fetch or parse errors fail open
+// (proceed with the update) so a flaky API call cannot silently disable
+// every update.
+func isSkippedByRepoConfig(
+	ctx context.Context,
+	provider repositories.ProviderRepository,
+	repo entities.Repository,
+) bool {
+	cfg, err := support.LoadRemoteRepoConfig(ctx, provider, repo)
+	if err != nil {
+		logger.Warnf("Could not read %s for %s/%s: %v (continuing without it)",
+			entities.RepoConfigFile, repo.Organization, repo.Name, err)
+		return false
+	}
+	if !cfg.IsSkipped() {
+		return false
+	}
+
+	if cfg.Reason != "" {
+		logger.Infof("Skipping %s/%s: %s requested skip (%s)",
+			repo.Organization, repo.Name, entities.RepoConfigFile, cfg.Reason)
+	} else {
+		logger.Infof("Skipping %s/%s: %s requested skip",
+			repo.Organization, repo.Name, entities.RepoConfigFile)
+	}
+	return true
 }
 
 // applicableUpdater holds an updater and its resolved options.
@@ -185,6 +222,10 @@ func (it *RunCommand) processRepository(
 	settings *entities.Settings,
 	runOpts RunOptions,
 ) ([]entities.PullRequest, int) {
+	if isSkippedByRepoConfig(ctx, provider, repo) {
+		return nil, 0
+	}
+
 	localUpdaters, legacyUpdaters := it.collectApplicableUpdaters(ctx, provider, repo, settings, runOpts)
 
 	var allPRs []entities.PullRequest

--- a/internal/domain/commands/run_command.go
+++ b/internal/domain/commands/run_command.go
@@ -157,17 +157,18 @@ func filterRepositories(
 
 	filtered := make([]entities.Repository, 0, len(repos))
 	for _, repo := range repos {
+		key := entities.RepoKey(repo)
 		if settings.ExcludeForks && repo.IsFork {
-			logger.Debugf("Skipping fork: %s/%s", repo.Organization, repo.Name)
+			logger.Debugf("Skipping fork: %s", key)
 			continue
 		}
 		if settings.ExcludeArchived && repo.IsArchived {
-			logger.Debugf("Skipping archived repo: %s/%s", repo.Organization, repo.Name)
+			logger.Debugf("Skipping archived repo: %s", key)
 			continue
 		}
 		if excluded, pattern := settings.IsRepoExcluded(repo); excluded {
-			logger.Infof("Skipping %s/%s: matched exclude_repos pattern %q",
-				repo.Organization, repo.Name, pattern)
+			logger.Infof("Skipping %s: matched exclude_repos pattern %q",
+				key, pattern)
 			continue
 		}
 		filtered = append(filtered, repo)
@@ -185,10 +186,11 @@ func isSkippedByRepoConfig(
 	provider repositories.ProviderRepository,
 	repo entities.Repository,
 ) bool {
+	key := entities.RepoKey(repo)
 	cfg, err := support.LoadRemoteRepoConfig(ctx, provider, repo)
 	if err != nil {
-		logger.Warnf("Could not read %s for %s/%s: %v (continuing without it)",
-			entities.RepoConfigFile, repo.Organization, repo.Name, err)
+		logger.Warnf("Could not read %s for %s: %v (continuing without it)",
+			entities.RepoConfigFile, key, err)
 		return false
 	}
 	if !cfg.IsSkipped() {
@@ -196,11 +198,11 @@ func isSkippedByRepoConfig(
 	}
 
 	if cfg.Reason != "" {
-		logger.Infof("Skipping %s/%s: %s requested skip (%s)",
-			repo.Organization, repo.Name, entities.RepoConfigFile, cfg.Reason)
+		logger.Infof("Skipping %s: %s requested skip (%s)",
+			key, entities.RepoConfigFile, cfg.Reason)
 	} else {
-		logger.Infof("Skipping %s/%s: %s requested skip",
-			repo.Organization, repo.Name, entities.RepoConfigFile)
+		logger.Infof("Skipping %s: %s requested skip",
+			key, entities.RepoConfigFile)
 	}
 	return true
 }

--- a/internal/domain/commands/run_command_test.go
+++ b/internal/domain/commands/run_command_test.go
@@ -1603,6 +1603,225 @@ func TestFilterRepositories(t *testing.T) {
 		// then
 		assert.Empty(t, result)
 	})
+
+	t.Run("should drop repos matching the global exclude_repos list", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repos := []entities.Repository{
+			{Organization: "ZestSecurity", Project: "frontend", Name: "opensearch-dashboards"},
+			{Organization: "ZestSecurity", Project: "frontend", Name: "oui"},
+			{Organization: "ZestSecurity", Project: "frontend", Name: "regular"},
+		}
+		settings := &entities.Settings{ExcludeRepos: []string{
+			"ZestSecurity/frontend/opensearch-dashboards",
+			"*/oui",
+		}}
+
+		// when
+		result := commands.FilterRepositories(repos, settings)
+
+		// then
+		require.Len(t, result, 1)
+		assert.Equal(t, "regular", result[0].Name)
+	})
+}
+
+func TestRunCommandRunsExcludeRepos(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should not call Detect on repos excluded by exclude_repos", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		excluded := entitybuilders.NewRepositoryBuilder().
+			WithID("excl").
+			WithName("opensearch-dashboards").
+			WithOrganization("ZestSecurity").
+			WithDefaultBranch("refs/heads/main").
+			BuildRepository()
+		excluded.Project = "frontend"
+
+		kept := entitybuilders.NewRepositoryBuilder().
+			WithID("kept").
+			WithName("regular").
+			WithOrganization("ZestSecurity").
+			WithDefaultBranch("refs/heads/main").
+			BuildRepository()
+
+		spy := doubles.NewSpyProviderRepositoryBuilder().
+			WithProviderName("azuredevops").
+			WithToken("ado-token").
+			WithRepositories([]entities.Repository{excluded, kept}).
+			BuildSpy()
+
+		updaterSpy := doubles.NewSpyUpdaterRepositoryBuilder().
+			WithUpdaterName("terraform").
+			WithDetectResult(true).
+			WithPRs([]entities.PullRequest{{ID: 1, Title: "Update", URL: "https://example.com/pr/1"}}).
+			BuildSpy()
+
+		providerRegistry := infraRepos.NewProviderRegistry()
+		providerRegistry.Register("azuredevops", func(_ string) repositories.ProviderRepository {
+			return spy
+		})
+
+		updaterRegistry := infraRepos.NewUpdaterRegistry()
+		updaterRegistry.Register(updaterSpy)
+
+		cmd := commands.NewRunCommand(providerRegistry, updaterRegistry)
+
+		settings := entitybuilders.NewSettingsBuilder().
+			WithProviders([]entities.ProviderConfig{
+				entitybuilders.NewProviderConfigBuilder().
+					WithType("azuredevops").
+					WithToken("ado-token").
+					WithOrganizations([]string{"ZestSecurity"}).
+					BuildProviderConfig(),
+			}).
+			WithExcludeRepos([]string{"ZestSecurity/frontend/opensearch-dashboards"}).
+			BuildSettings()
+
+		// when
+		err := cmd.Execute(context.Background(), settings, commands.RunOptions{})
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, updaterSpy.DetectedRepos, 1)
+		assert.Equal(t, "regular", updaterSpy.DetectedRepos[0].Name)
+	})
+}
+
+func TestRunCommandRunsRepoConfigSkip(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should not invoke updaters on a repo that requested skip via .autoupdate.yaml", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repo := entitybuilders.NewRepositoryBuilder().
+			WithID("opted-out").
+			WithName("opensearch-dashboards").
+			WithOrganization("ZestSecurity").
+			WithDefaultBranch("refs/heads/main").
+			BuildRepository()
+
+		spy := doubles.NewSpyProviderRepositoryBuilder().
+			WithProviderName("github").
+			WithToken("test-token").
+			WithRepositories([]entities.Repository{repo}).
+			WithExistingFiles(map[string]bool{entities.RepoConfigFile: true}).
+			WithFileContents(map[string]string{
+				entities.RepoConfigFile: "skip: true\nreason: \"fork\"\n",
+			}).
+			BuildSpy()
+
+		updaterSpy := doubles.NewSpyUpdaterRepositoryBuilder().
+			WithUpdaterName("terraform").
+			WithDetectResult(true).
+			BuildSpy()
+
+		providerRegistry := infraRepos.NewProviderRegistry()
+		providerRegistry.Register("github", func(_ string) repositories.ProviderRepository {
+			return spy
+		})
+
+		updaterRegistry := infraRepos.NewUpdaterRegistry()
+		updaterRegistry.Register(updaterSpy)
+
+		cmd := commands.NewRunCommand(providerRegistry, updaterRegistry)
+
+		settings := entitybuilders.NewSettingsBuilder().
+			WithProviders([]entities.ProviderConfig{
+				entitybuilders.NewProviderConfigBuilder().
+					WithType("github").
+					WithToken("test-token").
+					WithOrganizations([]string{"ZestSecurity"}).
+					BuildProviderConfig(),
+			}).
+			BuildSettings()
+
+		// when
+		err := cmd.Execute(context.Background(), settings, commands.RunOptions{})
+
+		// then
+		require.NoError(t, err)
+		assert.Empty(t, updaterSpy.DetectedRepos,
+			"Detect must not be called for a repo that opted out via .autoupdate.yaml")
+	})
+}
+
+func TestIsSkippedByRepoConfig(t *testing.T) {
+	t.Parallel()
+
+	repo := entities.Repository{Organization: "org", Name: "repo"}
+
+	t.Run("should return false when repo has no .autoupdate.yaml", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		spy := doubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{}).
+			BuildSpy()
+
+		// when
+		skipped := commands.IsSkippedByRepoConfig(context.Background(), spy, repo)
+
+		// then
+		assert.False(t, skipped)
+	})
+
+	t.Run("should return true when remote .autoupdate.yaml requests skip", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		spy := doubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{entities.RepoConfigFile: true}).
+			WithFileContents(map[string]string{
+				entities.RepoConfigFile: "skip: true\nreason: \"fork\"\n",
+			}).
+			BuildSpy()
+
+		// when
+		skipped := commands.IsSkippedByRepoConfig(context.Background(), spy, repo)
+
+		// then
+		assert.True(t, skipped)
+	})
+
+	t.Run("should return false when remote .autoupdate.yaml has skip: false", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		spy := doubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{entities.RepoConfigFile: true}).
+			WithFileContents(map[string]string{
+				entities.RepoConfigFile: "skip: false\n",
+			}).
+			BuildSpy()
+
+		// when
+		skipped := commands.IsSkippedByRepoConfig(context.Background(), spy, repo)
+
+		// then
+		assert.False(t, skipped)
+	})
+
+	t.Run("should fail open and continue when GetFileContent errors", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		spy := doubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{entities.RepoConfigFile: true}).
+			WithFileContentErr(errors.New("network down")).
+			BuildSpy()
+
+		// when
+		skipped := commands.IsSkippedByRepoConfig(context.Background(), spy, repo)
+
+		// then
+		assert.False(t, skipped)
+	})
 }
 
 func TestBuildAggregateBranchName(t *testing.T) {

--- a/internal/domain/entities/exclusion.go
+++ b/internal/domain/entities/exclusion.go
@@ -1,0 +1,73 @@
+package entities
+
+import (
+	"path"
+	"strings"
+)
+
+// RepoKey returns the canonical lookup key used by exclusion patterns.
+// Azure DevOps repos are addressed as <org>/<project>/<name> because the
+// project segment is part of the URL path; everything else is <org>/<name>.
+// All segments are lowercased so patterns are case-insensitive.
+func RepoKey(repo Repository) string {
+	parts := []string{repo.Organization}
+	if repo.Project != "" {
+		parts = append(parts, repo.Project)
+	}
+	parts = append(parts, repo.Name)
+
+	for i, p := range parts {
+		parts[i] = strings.ToLower(p)
+	}
+	return strings.Join(parts, "/")
+}
+
+// MatchesExcludePattern reports whether the repository's canonical key
+// matches any of the supplied glob patterns. Each pattern is matched
+// right-anchored against the segments of the key, so:
+//
+//   - `opensearch-dashboards` matches the repo named `opensearch-dashboards`
+//     regardless of org/project prefix.
+//   - `*/oui` matches `<anything>/oui`, including the trailing two
+//     segments of an Azure DevOps `org/project/oui` key.
+//   - `zestsecurity/frontend/opensearch-dashboards` only matches that
+//     exact ADO path.
+//
+// `*` follows `path.Match` semantics (it does not cross `/`). The first
+// matching pattern is returned alongside the boolean so callers can log
+// which rule excluded the repository.
+func MatchesExcludePattern(repo Repository, patterns []string) (bool, string) {
+	if len(patterns) == 0 {
+		return false, ""
+	}
+
+	keyParts := strings.Split(RepoKey(repo), "/")
+	for _, pattern := range patterns {
+		trimmed := strings.TrimSpace(pattern)
+		if trimmed == "" {
+			continue
+		}
+		normalized := strings.ToLower(trimmed)
+		patternParts := strings.Split(normalized, "/")
+
+		if len(patternParts) > len(keyParts) {
+			continue
+		}
+
+		suffix := strings.Join(keyParts[len(keyParts)-len(patternParts):], "/")
+		if matched, err := path.Match(normalized, suffix); err == nil && matched {
+			return true, trimmed
+		}
+	}
+	return false, ""
+}
+
+// IsRepoExcluded is a convenience wrapper that reads the exclude list off
+// the global Settings struct. A nil Settings or empty list disables the
+// check, mirroring the rest of the configuration surface.
+func (s *Settings) IsRepoExcluded(repo Repository) (bool, string) {
+	if s == nil {
+		return false, ""
+	}
+	return MatchesExcludePattern(repo, s.ExcludeRepos)
+}

--- a/internal/domain/entities/exclusion_test.go
+++ b/internal/domain/entities/exclusion_test.go
@@ -1,0 +1,267 @@
+//go:build unit
+
+package entities_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/rios0rios0/autoupdate/internal/domain/entities"
+)
+
+func TestRepoKey(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should join organization and name for GitHub-style repos", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repo := entities.Repository{Organization: "rios0rios0", Name: "autoupdate"}
+
+		// when
+		key := entities.RepoKey(repo)
+
+		// then
+		assert.Equal(t, "rios0rios0/autoupdate", key)
+	})
+
+	t.Run("should include project segment for Azure DevOps repos", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repo := entities.Repository{
+			Organization: "ZestSecurity",
+			Project:      "frontend",
+			Name:         "opensearch-dashboards",
+		}
+
+		// when
+		key := entities.RepoKey(repo)
+
+		// then
+		assert.Equal(t, "zestsecurity/frontend/opensearch-dashboards", key)
+	})
+
+	t.Run("should lowercase every segment for case-insensitive matching", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repo := entities.Repository{Organization: "MyOrg", Name: "MyRepo"}
+
+		// when
+		key := entities.RepoKey(repo)
+
+		// then
+		assert.Equal(t, "myorg/myrepo", key)
+	})
+}
+
+func TestMatchesExcludePattern(t *testing.T) {
+	t.Parallel()
+
+	githubRepo := entities.Repository{Organization: "rios0rios0", Name: "autoupdate"}
+	adoRepo := entities.Repository{
+		Organization: "ZestSecurity",
+		Project:      "frontend",
+		Name:         "opensearch-dashboards",
+	}
+
+	t.Run("should return false for empty pattern list", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		patterns := []string{}
+
+		// when
+		matched, pattern := entities.MatchesExcludePattern(githubRepo, patterns)
+
+		// then
+		assert.False(t, matched)
+		assert.Empty(t, pattern)
+	})
+
+	t.Run("should match exact org/repo patterns", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		patterns := []string{"rios0rios0/autoupdate"}
+
+		// when
+		matched, pattern := entities.MatchesExcludePattern(githubRepo, patterns)
+
+		// then
+		assert.True(t, matched)
+		assert.Equal(t, "rios0rios0/autoupdate", pattern)
+	})
+
+	t.Run("should match Azure DevOps three-segment paths", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		patterns := []string{"ZestSecurity/frontend/opensearch-dashboards"}
+
+		// when
+		matched, pattern := entities.MatchesExcludePattern(adoRepo, patterns)
+
+		// then
+		assert.True(t, matched)
+		assert.Equal(t, "ZestSecurity/frontend/opensearch-dashboards", pattern)
+	})
+
+	t.Run("should support glob wildcards on the org segment", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		patterns := []string{"*/oui"}
+		repo := entities.Repository{Organization: "ZestSecurity", Name: "oui"}
+
+		// when
+		matched, pattern := entities.MatchesExcludePattern(repo, patterns)
+
+		// then
+		assert.True(t, matched)
+		assert.Equal(t, "*/oui", pattern)
+	})
+
+	t.Run("should support glob wildcards spanning project and repo", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		patterns := []string{"zestsecurity/frontend/*"}
+
+		// when
+		matched, pattern := entities.MatchesExcludePattern(adoRepo, patterns)
+
+		// then
+		assert.True(t, matched)
+		assert.Equal(t, "zestsecurity/frontend/*", pattern)
+	})
+
+	t.Run("should match a bare repo name against the trailing segment", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		patterns := []string{"opensearch-dashboards"}
+
+		// when
+		matched, pattern := entities.MatchesExcludePattern(adoRepo, patterns)
+
+		// then
+		assert.True(t, matched)
+		assert.Equal(t, "opensearch-dashboards", pattern)
+	})
+
+	t.Run("should not match a partial repo name (right-anchored match only)", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		patterns := []string{"dashboards"}
+
+		// when
+		matched, _ := entities.MatchesExcludePattern(adoRepo, patterns)
+
+		// then
+		assert.False(t, matched, "use *dashboards or opensearch-dashboards instead")
+	})
+
+	t.Run("should be case-insensitive across patterns and keys", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		patterns := []string{"RIOS0RIOS0/AUTOUPDATE"}
+
+		// when
+		matched, _ := entities.MatchesExcludePattern(githubRepo, patterns)
+
+		// then
+		assert.True(t, matched)
+	})
+
+	t.Run("should ignore blank entries in the pattern list", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		patterns := []string{"", "   ", "rios0rios0/autoupdate"}
+
+		// when
+		matched, pattern := entities.MatchesExcludePattern(githubRepo, patterns)
+
+		// then
+		assert.True(t, matched)
+		assert.Equal(t, "rios0rios0/autoupdate", pattern)
+	})
+
+	t.Run("should return first matching pattern when multiple apply", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		patterns := []string{"*/autoupdate", "rios0rios0/autoupdate"}
+
+		// when
+		_, pattern := entities.MatchesExcludePattern(githubRepo, patterns)
+
+		// then
+		assert.Equal(t, "*/autoupdate", pattern)
+	})
+
+	t.Run("should not match unrelated repo", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		patterns := []string{"someorg/somerepo"}
+
+		// when
+		matched, _ := entities.MatchesExcludePattern(githubRepo, patterns)
+
+		// then
+		assert.False(t, matched)
+	})
+}
+
+func TestSettingsIsRepoExcluded(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return false on nil receiver", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		var settings *entities.Settings
+		repo := entities.Repository{Organization: "x", Name: "y"}
+
+		// when
+		matched, _ := settings.IsRepoExcluded(repo)
+
+		// then
+		assert.False(t, matched)
+	})
+
+	t.Run("should return false when ExcludeRepos is empty", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		settings := &entities.Settings{}
+		repo := entities.Repository{Organization: "x", Name: "y"}
+
+		// when
+		matched, _ := settings.IsRepoExcluded(repo)
+
+		// then
+		assert.False(t, matched)
+	})
+
+	t.Run("should match against ExcludeRepos list", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		settings := &entities.Settings{ExcludeRepos: []string{"x/y"}}
+		repo := entities.Repository{Organization: "x", Name: "y"}
+
+		// when
+		matched, pattern := settings.IsRepoExcluded(repo)
+
+		// then
+		assert.True(t, matched)
+		assert.Equal(t, "x/y", pattern)
+	})
+}

--- a/internal/domain/entities/repo_config.go
+++ b/internal/domain/entities/repo_config.go
@@ -1,0 +1,40 @@
+package entities
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// RepoConfigFile is the file name autoupdate looks for in a target
+// repository's root to read per-repository configuration.
+const RepoConfigFile = ".autoupdate.yaml"
+
+// RepoConfig is the schema for a target repository's .autoupdate.yaml.
+// It lets a project opt out of automated updates without touching the
+// global autoupdate configuration. When Skip is true the repository is
+// short-circuited before any updater runs.
+type RepoConfig struct {
+	Skip   bool   `yaml:"skip"`
+	Reason string `yaml:"reason"`
+}
+
+// IsSkipped reports whether the repository configuration requests that
+// autoupdate skip this project entirely.
+func (c *RepoConfig) IsSkipped() bool {
+	return c != nil && c.Skip
+}
+
+// ParseRepoConfig decodes raw YAML bytes into a RepoConfig. Empty input
+// returns a zero-value config so callers can treat "no file" and "empty
+// file" as equivalent.
+func ParseRepoConfig(data []byte) (*RepoConfig, error) {
+	var cfg RepoConfig
+	if len(data) == 0 {
+		return &cfg, nil
+	}
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", RepoConfigFile, err)
+	}
+	return &cfg, nil
+}

--- a/internal/domain/entities/repo_config_test.go
+++ b/internal/domain/entities/repo_config_test.go
@@ -1,0 +1,140 @@
+//go:build unit
+
+package entities_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rios0rios0/autoupdate/internal/domain/entities"
+)
+
+func TestRepoConfigIsSkipped(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return false for nil receiver", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		var cfg *entities.RepoConfig
+
+		// when
+		result := cfg.IsSkipped()
+
+		// then
+		assert.False(t, result)
+	})
+
+	t.Run("should return false for zero-value config", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		cfg := &entities.RepoConfig{}
+
+		// when
+		result := cfg.IsSkipped()
+
+		// then
+		assert.False(t, result)
+	})
+
+	t.Run("should return true when Skip is set", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		cfg := &entities.RepoConfig{Skip: true, Reason: "fork; rebase manually"}
+
+		// when
+		result := cfg.IsSkipped()
+
+		// then
+		assert.True(t, result)
+	})
+}
+
+func TestParseRepoConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return zero-value config for empty input", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		data := []byte("")
+
+		// when
+		cfg, err := entities.ParseRepoConfig(data)
+
+		// then
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.False(t, cfg.IsSkipped())
+		assert.Empty(t, cfg.Reason)
+	})
+
+	t.Run("should decode skip and reason", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		data := []byte("skip: true\nreason: \"fork of upstream; rebase manually\"\n")
+
+		// when
+		cfg, err := entities.ParseRepoConfig(data)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, cfg.IsSkipped())
+		assert.Equal(t, "fork of upstream; rebase manually", cfg.Reason)
+	})
+
+	t.Run("should decode skip without reason", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		data := []byte("skip: true\n")
+
+		// when
+		cfg, err := entities.ParseRepoConfig(data)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, cfg.IsSkipped())
+		assert.Empty(t, cfg.Reason)
+	})
+
+	t.Run("should ignore unknown keys for forward compatibility", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		data := []byte("skip: false\nfuture_key: something\n")
+
+		// when
+		cfg, err := entities.ParseRepoConfig(data)
+
+		// then
+		require.NoError(t, err)
+		assert.False(t, cfg.IsSkipped())
+	})
+
+	t.Run("should return error for malformed YAML", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		data := []byte("skip: : not-yaml")
+
+		// when
+		_, err := entities.ParseRepoConfig(data)
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), entities.RepoConfigFile)
+	})
+}
+
+func TestRepoConfigFileName(t *testing.T) {
+	t.Parallel()
+
+	// given/when/then
+	assert.Equal(t, ".autoupdate.yaml", entities.RepoConfigFile)
+}

--- a/internal/domain/entities/settings.go
+++ b/internal/domain/entities/settings.go
@@ -24,6 +24,7 @@ type Settings struct {
 	Updaters               map[string]UpdaterConfig `yaml:"updaters"`
 	ExcludeForks           bool                     `yaml:"exclude_forks"`
 	ExcludeArchived        bool                     `yaml:"exclude_archived"`
+	ExcludeRepos           []string                 `yaml:"exclude_repos"`
 	GpgKeyPath             string                   `yaml:"gpg_key_path"`
 	GpgKeyPassphrase       string                   `yaml:"gpg_key_passphrase"`
 	GitHubAccessToken      string                   `yaml:"github_access_token"`

--- a/internal/domain/entities/settings.go
+++ b/internal/domain/entities/settings.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"path"
 	"strings"
 
 	configEntities "github.com/rios0rios0/gitforge/pkg/config/domain/entities"
@@ -124,6 +125,17 @@ func ValidateSettings(settings *Settings) error {
 				"providers[%d].organizations must have at least one entry",
 				i,
 			)
+		}
+	}
+
+	for i, pattern := range settings.ExcludeRepos {
+		trimmed := strings.TrimSpace(pattern)
+		if trimmed == "" {
+			continue
+		}
+		if _, err := path.Match(trimmed, "probe"); err != nil {
+			return fmt.Errorf("exclude_repos[%d] %q: invalid glob pattern: %w",
+				i, pattern, err)
 		}
 	}
 

--- a/internal/domain/entities/settings_test.go
+++ b/internal/domain/entities/settings_test.go
@@ -306,6 +306,67 @@ func TestValidateSettings(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "organizations must have at least one entry")
 	})
+
+	t.Run("should accept valid exclude_repos patterns", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		settings := &entities.Settings{
+			Providers: []entities.ProviderConfig{
+				{Type: "github", Token: "tok", Organizations: []string{"org"}},
+			},
+			ExcludeRepos: []string{
+				"rios0rios0/autoupdate",
+				"*/oui",
+				"zestsecurity/frontend/*",
+				"opensearch-dashboards",
+			},
+		}
+
+		// when
+		err := entities.ValidateSettings(settings)
+
+		// then
+		assert.NoError(t, err)
+	})
+
+	t.Run("should ignore blank exclude_repos entries", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		settings := &entities.Settings{
+			Providers: []entities.ProviderConfig{
+				{Type: "github", Token: "tok", Organizations: []string{"org"}},
+			},
+			ExcludeRepos: []string{"", "   ", "rios0rios0/autoupdate"},
+		}
+
+		// when
+		err := entities.ValidateSettings(settings)
+
+		// then
+		assert.NoError(t, err)
+	})
+
+	t.Run("should return error for invalid glob patterns in exclude_repos", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		settings := &entities.Settings{
+			Providers: []entities.ProviderConfig{
+				{Type: "github", Token: "tok", Organizations: []string{"org"}},
+			},
+			ExcludeRepos: []string{"valid/repo", "bad/[unclosed"},
+		}
+
+		// when
+		err := entities.ValidateSettings(settings)
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exclude_repos[1]")
+		assert.Contains(t, err.Error(), "bad/[unclosed")
+	})
 }
 
 func TestInsertChangelogEntry(t *testing.T) {

--- a/internal/infrastructure/controllers/local_controller.go
+++ b/internal/infrastructure/controllers/local_controller.go
@@ -34,6 +34,7 @@ Detects the project type, upgrades dependencies, and creates a pull request.`,
 func (it *LocalController) Execute(cmd *cobra.Command, args []string) {
 	ctx := context.Background()
 
+	configPath, _ := cmd.Flags().GetString("config")
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	token, _ := cmd.Flags().GetString("token")
@@ -43,11 +44,18 @@ func (it *LocalController) Execute(cmd *cobra.Command, args []string) {
 		repoDir = args[0]
 	}
 
+	settings, configErr := findReadAndValidateConfig(configPath)
+	if configErr != nil {
+		logger.Debugf("No usable autoupdate config for local mode: %v", configErr)
+		settings = nil
+	}
+
 	if err := it.command.Execute(ctx, commands.LocalOptions{
-		RepoDir: repoDir,
-		DryRun:  dryRun,
-		Verbose: verbose,
-		Token:   token,
+		RepoDir:  repoDir,
+		DryRun:   dryRun,
+		Verbose:  verbose,
+		Token:    token,
+		Settings: settings,
 	}); err != nil {
 		logger.Errorf("Local update failed: %v", err)
 	}

--- a/internal/support/repo_config_loader.go
+++ b/internal/support/repo_config_loader.go
@@ -43,8 +43,8 @@ func LoadRemoteRepoConfig(
 
 	content, err := provider.GetFileContent(ctx, repo, entities.RepoConfigFile)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch %s for %s/%s: %w",
-			entities.RepoConfigFile, repo.Organization, repo.Name, err)
+		return nil, fmt.Errorf("failed to fetch %s for %s: %w",
+			entities.RepoConfigFile, entities.RepoKey(repo), err)
 	}
 	return entities.ParseRepoConfig([]byte(content))
 }

--- a/internal/support/repo_config_loader.go
+++ b/internal/support/repo_config_loader.go
@@ -1,0 +1,50 @@
+package support
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/rios0rios0/autoupdate/internal/domain/entities"
+	"github.com/rios0rios0/autoupdate/internal/domain/repositories"
+)
+
+// LoadLocalRepoConfig reads the per-repository .autoupdate.yaml from a
+// directory on disk. A missing file is treated as "no config" and returns
+// the zero-value RepoConfig with no error so callers can use the result
+// unconditionally.
+func LoadLocalRepoConfig(repoDir string) (*entities.RepoConfig, error) {
+	path := filepath.Join(repoDir, entities.RepoConfigFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &entities.RepoConfig{}, nil
+		}
+		return nil, fmt.Errorf("failed to read %s: %w", path, err)
+	}
+	return entities.ParseRepoConfig(data)
+}
+
+// LoadRemoteRepoConfig reads the per-repository .autoupdate.yaml via the
+// provider's file-access API. A repository without the file returns the
+// zero-value config without making the second round-trip to fetch
+// content. Transient errors fetching content are propagated so callers
+// can decide whether to fail-open or fail-closed.
+func LoadRemoteRepoConfig(
+	ctx context.Context,
+	provider repositories.ProviderRepository,
+	repo entities.Repository,
+) (*entities.RepoConfig, error) {
+	if !provider.HasFile(ctx, repo, entities.RepoConfigFile) {
+		return &entities.RepoConfig{}, nil
+	}
+
+	content, err := provider.GetFileContent(ctx, repo, entities.RepoConfigFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch %s for %s/%s: %w",
+			entities.RepoConfigFile, repo.Organization, repo.Name, err)
+	}
+	return entities.ParseRepoConfig([]byte(content))
+}

--- a/internal/support/repo_config_loader_test.go
+++ b/internal/support/repo_config_loader_test.go
@@ -1,0 +1,130 @@
+//go:build unit
+
+package support_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rios0rios0/autoupdate/internal/domain/entities"
+	"github.com/rios0rios0/autoupdate/internal/support"
+	doubles "github.com/rios0rios0/autoupdate/test/infrastructure/repositorydoubles"
+)
+
+func TestLoadLocalRepoConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return empty config when file is missing", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		dir := t.TempDir()
+
+		// when
+		cfg, err := support.LoadLocalRepoConfig(dir)
+
+		// then
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.False(t, cfg.IsSkipped())
+	})
+
+	t.Run("should parse skip directive when file exists", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		dir := t.TempDir()
+		path := filepath.Join(dir, entities.RepoConfigFile)
+		require.NoError(t, os.WriteFile(path,
+			[]byte("skip: true\nreason: \"fork\"\n"), 0o600))
+
+		// when
+		cfg, err := support.LoadLocalRepoConfig(dir)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, cfg.IsSkipped())
+		assert.Equal(t, "fork", cfg.Reason)
+	})
+
+	t.Run("should propagate parse errors for malformed YAML", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		dir := t.TempDir()
+		path := filepath.Join(dir, entities.RepoConfigFile)
+		require.NoError(t, os.WriteFile(path,
+			[]byte("skip: : not-yaml"), 0o600))
+
+		// when
+		_, err := support.LoadLocalRepoConfig(dir)
+
+		// then
+		require.Error(t, err)
+	})
+}
+
+func TestLoadRemoteRepoConfig(t *testing.T) {
+	t.Parallel()
+
+	repo := entities.Repository{Organization: "org", Name: "repo"}
+
+	t.Run("should return empty config when provider reports no file", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		spy := doubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{}).
+			BuildSpy()
+
+		// when
+		cfg, err := support.LoadRemoteRepoConfig(context.Background(), spy, repo)
+
+		// then
+		require.NoError(t, err)
+		assert.False(t, cfg.IsSkipped())
+	})
+
+	t.Run("should parse remote skip directive", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		spy := doubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{entities.RepoConfigFile: true}).
+			WithFileContents(map[string]string{
+				entities.RepoConfigFile: "skip: true\nreason: \"manually maintained\"\n",
+			}).
+			BuildSpy()
+
+		// when
+		cfg, err := support.LoadRemoteRepoConfig(context.Background(), spy, repo)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, cfg.IsSkipped())
+		assert.Equal(t, "manually maintained", cfg.Reason)
+	})
+
+	t.Run("should return error when GetFileContent fails", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		spy := doubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{entities.RepoConfigFile: true}).
+			WithFileContentErr(errors.New("api blew up")).
+			BuildSpy()
+
+		// when
+		_, err := support.LoadRemoteRepoConfig(context.Background(), spy, repo)
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), entities.RepoConfigFile)
+	})
+}

--- a/test/domain/entitybuilders/settings_builder.go
+++ b/test/domain/entitybuilders/settings_builder.go
@@ -14,6 +14,7 @@ type SettingsBuilder struct {
 	updaters        map[string]entities.UpdaterConfig
 	excludeForks    bool
 	excludeArchived bool
+	excludeRepos    []string
 }
 
 // NewSettingsBuilder creates a new settings builder with sensible defaults.
@@ -49,6 +50,12 @@ func (b *SettingsBuilder) WithExcludeArchived(exclude bool) *SettingsBuilder {
 	return b
 }
 
+// WithExcludeRepos sets the global repository exclusion patterns.
+func (b *SettingsBuilder) WithExcludeRepos(patterns []string) *SettingsBuilder {
+	b.excludeRepos = patterns
+	return b
+}
+
 // Build creates the settings (satisfies testkit.Builder interface).
 func (b *SettingsBuilder) Build() interface{} {
 	return b.BuildSettings()
@@ -61,6 +68,7 @@ func (b *SettingsBuilder) BuildSettings() *entities.Settings {
 		Updaters:        b.updaters,
 		ExcludeForks:    b.excludeForks,
 		ExcludeArchived: b.excludeArchived,
+		ExcludeRepos:    b.excludeRepos,
 	}
 }
 
@@ -71,6 +79,7 @@ func (b *SettingsBuilder) Reset() testkit.Builder {
 	b.updaters = map[string]entities.UpdaterConfig{}
 	b.excludeForks = false
 	b.excludeArchived = false
+	b.excludeRepos = nil
 	return b
 }
 
@@ -84,11 +93,15 @@ func (b *SettingsBuilder) Clone() testkit.Builder {
 		updaters[k] = v
 	}
 
+	excludeRepos := make([]string, len(b.excludeRepos))
+	copy(excludeRepos, b.excludeRepos)
+
 	return &SettingsBuilder{
 		BaseBuilder:     b.BaseBuilder.Clone().(*testkit.BaseBuilder),
 		providers:       providers,
 		updaters:        updaters,
 		excludeForks:    b.excludeForks,
 		excludeArchived: b.excludeArchived,
+		excludeRepos:    excludeRepos,
 	}
 }


### PR DESCRIPTION
## Summary

Adds two complementary ways to skip repositories during dependency updates:

- **`.autoupdate.yaml` (per-repo opt-out)**: drop a file with `skip: true` (and an optional `reason`) into the target repository's root. Honored by both `autoupdate run` (read via the provider API on the default branch) and `autoupdate .` (read from disk) before any updater runs.
- **`exclude_repos` (global glob list)**: list of right-anchored glob patterns in the user's `autoupdate.yaml`. Matched against `<org>/<repo>` for GitHub/GitLab and `<org>/<project>/<repo>` for Azure DevOps. `*` follows `path.Match` semantics (does not cross `/`); a bare name matches just the trailing segment, so `opensearch-dashboards` and `*/oui` both work.

The two features compose: forks/mirrors you maintain by hand can either carry the per-repo file (preferred — survives clone/move) or be listed centrally in `exclude_repos` (no fork edits required).

### Implementation notes

- New entities: `RepoConfig` (`internal/domain/entities/repo_config.go`) and the `MatchesExcludePattern` / `RepoKey` helpers (`internal/domain/entities/exclusion.go`).
- Loader split: `support.LoadLocalRepoConfig` (filesystem) and `support.LoadRemoteRepoConfig` (`FileAccessProvider.GetFileContent`). Remote fetch errors fail open so a flaky API can never silently disable all updates.
- `RunCommand` checks the remote `.autoupdate.yaml` in `processRepository` before any updater, and applies `exclude_repos` in `filterRepositories`.
- `LocalCommand` always honors the on-disk `.autoupdate.yaml`, and additionally honors `exclude_repos` when `LocalController` was able to load a config file.
- `LocalCommand.Execute` was reordered: Git remote detection now runs before language detection, so excluded repos no longer fail because they lack a supported project layout.

## Test plan

- [x] Unit tests: `go test -tags unit ./...` (all packages green).
- [x] BDD-style tests for `RepoConfig`, `MatchesExcludePattern`, `RepoKey`, `LoadLocalRepoConfig`, `LoadRemoteRepoConfig`, `filterRepositories` (with `exclude_repos`), `isSkippedByRepoConfig`, `checkLocalRepoConfigSkip`, `isExcludedByGlobalList`, and end-to-end coverage through `RunCommand.Execute` and `LocalCommand.Execute`.
- [x] `go vet ./...` clean, `make lint` reports `0 issues.`
- [x] Documented in `README.md`, `configs/autoupdate.yaml`, `CHANGELOG.md`, and `.github/copilot-instructions.md`.

## Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?
- [x] Did you run all the code checks? (`go test`)
- [x] Are the tests passing?

🤖 Generated with [Claude Code](https://claude.com/claude-code)