### PR TITLE
feat(run): process repositories in parallel with configurable concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added parallel repository processing to `autoupdate run`, configurable via the `concurrency` config field and the `--concurrency` flag, so large organizations finish well within CI time limits
+
+### Changed
+
+- changed `autoupdate run` to process repositories within an organization in parallel (default 4 at a time) instead of one at a time; set `concurrency: 1` to restore the previous sequential behavior
+
 ## [0.15.8] - 2026-06-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ providers:
     organizations:
       - "my-group"
 
+# Number of repositories to process in parallel within an organization.
+# Processing is I/O-bound (clone + remote API calls), so a small fan-out
+# shortens large-organization runs significantly. Omit it (or set 0) to use
+# the built-in default of 4; set 1 to process repositories sequentially. The
+# --concurrency CLI flag overrides this value when provided.
+concurrency: 4
+
 # Skip specific repos globally without touching each project. Patterns
 # are right-anchored against the canonical key:
 #   - GitHub/GitLab: <org>/<repo>
@@ -248,11 +255,12 @@ Standalone local mode -- update a single repository in place.
 
 Batch mode -- discover and update repositories using a config file.
 
-| Flag         | Description                                            |
-|--------------|--------------------------------------------------------|
-| `--provider` | Only process this provider (github/gitlab/azuredevops) |
-| `--org`      | Only process this organization/group                   |
-| `--updater`  | Only run this updater (terraform/golang)               |
+| Flag            | Description                                                       |
+|-----------------|------------------------------------------------------------------|
+| `--provider`    | Only process this provider (github/gitlab/azuredevops)           |
+| `--org`         | Only process this organization/group                             |
+| `--updater`     | Only run this updater (terraform/golang)                         |
+| `--concurrency` | Repositories processed in parallel (default 4; 1 = sequential)   |
 
 ## Contributing
 

--- a/configs/autoupdate.yaml
+++ b/configs/autoupdate.yaml
@@ -18,13 +18,20 @@ providers:
   #   organizations:
   #     - "my-group"
 
+# Number of repositories to process in parallel within an organization.
+# Repository processing is I/O-bound (clone + remote API calls), so a small
+# fan-out shortens large-organization runs significantly. Omit it (or set 0)
+# to use the built-in default of 4; set 1 to process repositories sequentially.
+# The --concurrency CLI flag, when provided, overrides this value.
+# concurrency: 4
+
 # Skip specific repositories globally. Patterns are right-anchored
 # against <org>/<repo> (or <org>/<project>/<repo> on Azure DevOps), and
 # support `path.Match`-style globs (`*`, `?`, `[...]`) that do not cross
 # "/". A bare name matches the trailing segment of the key.
 # exclude_repos:
-#   - 'ZestSecurity/frontend/opensearch-dashboards'
-#   - '*/oui'
+#   - 'my-org/legacy-monorepo'
+#   - '*/sandbox'
 
 # All updaters are enabled by default with auto_complete disabled.
 # Users only need to override specific fields; omitted fields keep these defaults.

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/zclconf/go-cty v1.18.1
 	go.uber.org/dig v1.19.0
 	golang.org/x/mod v0.36.0
+	golang.org/x/sync v0.20.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -51,7 +52,6 @@ require (
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect

--- a/internal/domain/commands/export_test.go
+++ b/internal/domain/commands/export_test.go
@@ -94,3 +94,9 @@ var FirstLine = firstLine //nolint:gochecknoglobals // test export
 
 // ResolveAggregateTargetBranch exports resolveAggregateTargetBranch for testing.
 var ResolveAggregateTargetBranch = resolveAggregateTargetBranch //nolint:gochecknoglobals // test export
+
+// ResolveConcurrency exports resolveConcurrency for testing.
+var ResolveConcurrency = resolveConcurrency //nolint:gochecknoglobals // test export
+
+// DefaultRepoConcurrency exports defaultRepoConcurrency for testing.
+const DefaultRepoConcurrency = defaultRepoConcurrency

--- a/internal/domain/commands/run_command.go
+++ b/internal/domain/commands/run_command.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	logger "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/rios0rios0/autoupdate/internal/domain/entities"
 	"github.com/rios0rios0/autoupdate/internal/domain/repositories"
@@ -17,6 +19,13 @@ import (
 	"github.com/rios0rios0/autoupdate/internal/support"
 	gitops "github.com/rios0rios0/gitforge/pkg/git/infrastructure"
 )
+
+// defaultRepoConcurrency is the number of repositories processed in parallel
+// within an organization when neither the config file nor the CLI overrides it.
+// Repository processing is I/O-bound (clone + remote API calls), so a small
+// fan-out yields a near-linear speedup without overwhelming provider rate
+// limits or local disk. Set concurrency to 1 to restore sequential processing.
+const defaultRepoConcurrency = 4
 
 // Run is the interface for the run command (batch mode).
 type Run interface {
@@ -30,6 +39,7 @@ type RunOptions struct {
 	ProviderName string // If set, only process this provider (CLI override)
 	OrgOverride  string // If set, only process this org (CLI override)
 	UpdaterName  string // If set, only run this updater (CLI override)
+	Concurrency  int    // If > 0, process this many repos in parallel (CLI override)
 }
 
 // RunCommand orchestrates the full dependency update flow:
@@ -131,17 +141,57 @@ func (it *RunCommand) processOrganization(
 	}
 
 	repos = filterRepositories(repos, settings)
-	logger.Infof("Found %d repositories in %q", len(repos), org)
+	concurrency := resolveConcurrency(settings, runOpts)
+	logger.Infof("Found %d repositories in %q (processing up to %d in parallel)",
+		len(repos), org, concurrency)
 
-	totalPRs, totalRepos, totalErrors := 0, 0, 0
+	// Repository processing is independent and I/O-bound (clone + remote API
+	// calls), so repos are processed concurrently with a bounded worker pool.
+	// Each repo clones into its own temp directory, the shared provider/updater
+	// instances are stateless, and the aggregate counters are guarded by a
+	// mutex, so the fan-out is safe. Per-repo failures are counted (not
+	// propagated) to preserve the "continue on error" behavior, so the
+	// goroutines never return an error and Wait cannot fail.
+	var (
+		mu          sync.Mutex
+		totalPRs    int
+		totalErrors int
+	)
+
+	var group errgroup.Group
+	group.SetLimit(concurrency)
 	for _, repo := range repos {
-		totalRepos++
-		prs, errs := it.processRepository(ctx, provider, repo, settings, runOpts)
-		totalPRs += len(prs)
-		totalErrors += errs
+		group.Go(func() error {
+			prs, errs := it.processRepository(ctx, provider, repo, settings, runOpts)
+			mu.Lock()
+			totalPRs += len(prs)
+			totalErrors += errs
+			mu.Unlock()
+			return nil
+		})
 	}
+	_ = group.Wait()
 
-	return totalPRs, totalRepos, totalErrors
+	return totalPRs, len(repos), totalErrors
+}
+
+// resolveConcurrency determines how many repositories to process in parallel.
+// Precedence: CLI override (runOpts) > config file (settings) > built-in
+// default. A zero value at a given level means "not set" and falls through to
+// the next level; any explicitly set value below 1 is clamped to 1 (fully
+// sequential).
+func resolveConcurrency(settings *entities.Settings, runOpts RunOptions) int {
+	concurrency := defaultRepoConcurrency
+	if settings != nil && settings.Concurrency != 0 {
+		concurrency = settings.Concurrency
+	}
+	if runOpts.Concurrency != 0 {
+		concurrency = runOpts.Concurrency
+	}
+	if concurrency < 1 {
+		concurrency = 1
+	}
+	return concurrency
 }
 
 // filterRepositories removes repositories that match the exclusion criteria

--- a/internal/domain/commands/run_command_test.go
+++ b/internal/domain/commands/run_command_test.go
@@ -5,6 +5,7 @@ package commands_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -1137,9 +1138,14 @@ func TestRunCommandExecute(t *testing.T) {
 
 		// then
 		require.NoError(t, err)
-		assert.Len(t, updaterSpy.DetectedRepos, 2)
-		assert.Equal(t, "repo-alpha", updaterSpy.DetectedRepos[0].Name)
-		assert.Equal(t, "repo-beta", updaterSpy.DetectedRepos[1].Name)
+		require.Len(t, updaterSpy.DetectedRepos, 2)
+		// Repositories are processed concurrently, so the recorded order is
+		// not deterministic; assert on set membership instead of position.
+		detectedNames := []string{
+			updaterSpy.DetectedRepos[0].Name,
+			updaterSpy.DetectedRepos[1].Name,
+		}
+		assert.ElementsMatch(t, []string{"repo-alpha", "repo-beta"}, detectedNames)
 		assert.Len(t, updaterSpy.CreatePRsCalls, 2)
 	})
 
@@ -2197,5 +2203,213 @@ func TestFirstLine(t *testing.T) {
 
 		// then
 		assert.Equal(t, "single line", result)
+	})
+}
+
+func TestResolveConcurrency(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should use the built-in default when neither config nor CLI set it", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		settings := &entities.Settings{}
+		opts := commands.RunOptions{}
+
+		// when
+		result := commands.ResolveConcurrency(settings, opts)
+
+		// then
+		assert.Equal(t, commands.DefaultRepoConcurrency, result)
+	})
+
+	t.Run("should use the built-in default when settings is nil", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		opts := commands.RunOptions{}
+
+		// when
+		result := commands.ResolveConcurrency(nil, opts)
+
+		// then
+		assert.Equal(t, commands.DefaultRepoConcurrency, result)
+	})
+
+	t.Run("should use the config value when only settings sets it", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		settings := &entities.Settings{Concurrency: 8}
+		opts := commands.RunOptions{}
+
+		// when
+		result := commands.ResolveConcurrency(settings, opts)
+
+		// then
+		assert.Equal(t, 8, result)
+	})
+
+	t.Run("should let the CLI override take precedence over the config value", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		settings := &entities.Settings{Concurrency: 8}
+		opts := commands.RunOptions{Concurrency: 2}
+
+		// when
+		result := commands.ResolveConcurrency(settings, opts)
+
+		// then
+		assert.Equal(t, 2, result)
+	})
+
+	t.Run("should honor an explicit concurrency of 1 (sequential)", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		settings := &entities.Settings{Concurrency: 1}
+		opts := commands.RunOptions{}
+
+		// when
+		result := commands.ResolveConcurrency(settings, opts)
+
+		// then
+		assert.Equal(t, 1, result)
+	})
+
+	t.Run("should clamp a non-positive config value to 1", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		settings := &entities.Settings{Concurrency: -4}
+		opts := commands.RunOptions{}
+
+		// when
+		result := commands.ResolveConcurrency(settings, opts)
+
+		// then
+		assert.Equal(t, 1, result)
+	})
+
+	t.Run("should clamp a non-positive CLI override to 1", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		settings := &entities.Settings{Concurrency: 8}
+		opts := commands.RunOptions{Concurrency: -1}
+
+		// when
+		result := commands.ResolveConcurrency(settings, opts)
+
+		// then
+		assert.Equal(t, 1, result)
+	})
+}
+
+func TestRunCommandConcurrency(t *testing.T) {
+	t.Parallel()
+
+	// setupRun wires a run command to a provider serving repoCount repositories
+	// and a single detect-everything updater. It returns the command, the
+	// updater spy (for assertions), and the settings, keeping each subtest
+	// focused on the one thing that differs: how concurrency is configured.
+	setupRun := func(repoCount int) (
+		*commands.RunCommand, *doubles.SpyUpdaterRepository, *entities.Settings,
+	) {
+		repos := make([]entities.Repository, 0, repoCount)
+		for i := range repoCount {
+			repos = append(repos, entitybuilders.NewRepositoryBuilder().
+				WithID(fmt.Sprintf("repo-%d", i)).
+				WithName(fmt.Sprintf("repo-%d", i)).
+				WithOrganization("test-org").
+				WithDefaultBranch("refs/heads/main").
+				BuildRepository())
+		}
+
+		providerSpy := doubles.NewSpyProviderRepositoryBuilder().
+			WithProviderName("github").
+			WithToken("test-token").
+			WithRepositories(repos).
+			BuildSpy()
+		updaterSpy := doubles.NewSpyUpdaterRepositoryBuilder().
+			WithUpdaterName("terraform").
+			WithDetectResult(true).
+			WithPRs([]entities.PullRequest{{ID: 1, Title: "Update", URL: "https://example.com/pr/1"}}).
+			BuildSpy()
+
+		providerRegistry := infraRepos.NewProviderRegistry()
+		providerRegistry.Register("github", func(_ string) repositories.ProviderRepository {
+			return providerSpy
+		})
+		updaterRegistry := infraRepos.NewUpdaterRegistry()
+		updaterRegistry.Register(updaterSpy)
+
+		settings := entitybuilders.NewSettingsBuilder().
+			WithProviders([]entities.ProviderConfig{
+				entitybuilders.NewProviderConfigBuilder().
+					WithType("github").
+					WithToken("test-token").
+					WithOrganizations([]string{"test-org"}).
+					BuildProviderConfig(),
+			}).
+			BuildSettings()
+
+		return commands.NewRunCommand(providerRegistry, updaterRegistry), updaterSpy, settings
+	}
+
+	// assertAllProcessed checks that every repository was detected and turned
+	// into a CreateUpdatePRs call, regardless of the (non-deterministic)
+	// concurrent processing order.
+	assertAllProcessed := func(t *testing.T, updaterSpy *doubles.SpyUpdaterRepository, want int) {
+		t.Helper()
+		assert.Len(t, updaterSpy.DetectedRepos, want)
+		assert.Len(t, updaterSpy.CreatePRsCalls, want)
+	}
+
+	t.Run("should process every repository when running in parallel", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		const repoCount = 12
+		cmd, updaterSpy, settings := setupRun(repoCount)
+
+		// when
+		err := cmd.Execute(context.Background(), settings, commands.RunOptions{Concurrency: 4})
+
+		// then
+		require.NoError(t, err)
+		assertAllProcessed(t, updaterSpy, repoCount)
+	})
+
+	t.Run("should process every repository when forced sequential", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		const repoCount = 5
+		cmd, updaterSpy, settings := setupRun(repoCount)
+
+		// when
+		err := cmd.Execute(context.Background(), settings, commands.RunOptions{Concurrency: 1})
+
+		// then
+		require.NoError(t, err)
+		assertAllProcessed(t, updaterSpy, repoCount)
+	})
+
+	t.Run("should drive parallelism from settings when no CLI override is given", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		const repoCount = 8
+		cmd, updaterSpy, settings := setupRun(repoCount)
+		settings.Concurrency = 3
+
+		// when
+		err := cmd.Execute(context.Background(), settings, commands.RunOptions{})
+
+		// then
+		require.NoError(t, err)
+		assertAllProcessed(t, updaterSpy, repoCount)
 	})
 }

--- a/internal/domain/entities/settings.go
+++ b/internal/domain/entities/settings.go
@@ -21,17 +21,22 @@ type ProviderConfig = configEntities.ProviderConfig
 
 // Settings is the top-level configuration for autoupdate, loaded from YAML.
 type Settings struct {
-	Providers              []ProviderConfig         `yaml:"providers"`
-	Updaters               map[string]UpdaterConfig `yaml:"updaters"`
-	ExcludeForks           bool                     `yaml:"exclude_forks"`
-	ExcludeArchived        bool                     `yaml:"exclude_archived"`
-	ExcludeRepos           []string                 `yaml:"exclude_repos"`
-	GpgKeyPath             string                   `yaml:"gpg_key_path"`
-	GpgKeyPassphrase       string                   `yaml:"gpg_key_passphrase"`
-	GitHubAccessToken      string                   `yaml:"github_access_token"`
-	GitLabAccessToken      string                   `yaml:"gitlab_access_token"`
-	AzureDevOpsAccessToken string                   `yaml:"azure_devops_access_token"`
-	GitLabCIJobToken       string                   `yaml:"-"`
+	Providers       []ProviderConfig         `yaml:"providers"`
+	Updaters        map[string]UpdaterConfig `yaml:"updaters"`
+	ExcludeForks    bool                     `yaml:"exclude_forks"`
+	ExcludeArchived bool                     `yaml:"exclude_archived"`
+	ExcludeRepos    []string                 `yaml:"exclude_repos"`
+	// Concurrency is how many repositories are processed in parallel within an
+	// organization. Zero (the default) lets the run command pick a sensible
+	// built-in default; 1 forces fully sequential processing. A CLI flag, when
+	// provided, takes precedence over this value.
+	Concurrency            int    `yaml:"concurrency"`
+	GpgKeyPath             string `yaml:"gpg_key_path"`
+	GpgKeyPassphrase       string `yaml:"gpg_key_passphrase"`
+	GitHubAccessToken      string `yaml:"github_access_token"`
+	GitLabAccessToken      string `yaml:"gitlab_access_token"`
+	AzureDevOpsAccessToken string `yaml:"azure_devops_access_token"`
+	GitLabCIJobToken       string `yaml:"-"`
 }
 
 // UpdaterConfig holds per-updater settings.

--- a/internal/infrastructure/controllers/run_controller.go
+++ b/internal/infrastructure/controllers/run_controller.go
@@ -45,6 +45,7 @@ func (it *RunController) Execute(cmd *cobra.Command, _ []string) {
 	providerFilter, _ := cmd.Flags().GetString("provider")
 	orgOverride, _ := cmd.Flags().GetString("org")
 	updaterFilter, _ := cmd.Flags().GetString("updater")
+	concurrency, _ := cmd.Flags().GetInt("concurrency")
 
 	settings, err := findReadAndValidateConfig(configPath)
 	if err != nil {
@@ -60,6 +61,7 @@ func (it *RunController) Execute(cmd *cobra.Command, _ []string) {
 		ProviderName: providerFilter,
 		OrgOverride:  orgOverride,
 		UpdaterName:  updaterFilter,
+		Concurrency:  concurrency,
 	}); runErr != nil {
 		logger.Errorf("Run failed: %v", runErr)
 	}
@@ -71,5 +73,8 @@ func (it *RunController) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().String("org", "", "Only process this organization/group")
 	cmd.Flags().String("updater", "",
 		"Only run this updater (terraform, golang, python, javascript, pipeline, dockerfile)",
+	)
+	cmd.Flags().Int("concurrency", 0,
+		"Number of repositories to process in parallel (default 4; 1 = sequential)",
 	)
 }

--- a/test/infrastructure/repositorydoubles/stub_provider_repository.go
+++ b/test/infrastructure/repositorydoubles/stub_provider_repository.go
@@ -7,20 +7,26 @@ package repositorydoubles //nolint:revive,staticcheck // Test package naming fol
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/rios0rios0/autoupdate/internal/domain/entities"
 	"github.com/rios0rios0/autoupdate/internal/domain/repositories"
 )
 
 // SpyProviderRepository implements repositories.ProviderRepository as a configurable spy.
+// The recorder slices are guarded by mu because the run command processes
+// repositories concurrently, so the provider methods may be called from
+// multiple goroutines against the same shared spy.
 type SpyProviderRepository struct {
+	mu sync.Mutex
+
 	// --- identity ---
 	ProviderName string
 	Token        string
 
 	// --- DiscoverRepositories ---
-	Repositories []entities.Repository
-	DiscoverErr  error
+	Repositories   []entities.Repository
+	DiscoverErr    error
 	DiscoveredOrgs []string
 
 	// --- GetFileContent ---
@@ -55,14 +61,16 @@ type SpyProviderRepository struct {
 
 var _ repositories.ProviderRepository = (*SpyProviderRepository)(nil)
 
-func (p *SpyProviderRepository) Name() string     { return p.ProviderName }
-func (p *SpyProviderRepository) AuthToken() string { return p.Token }
+func (p *SpyProviderRepository) Name() string             { return p.ProviderName }
+func (p *SpyProviderRepository) AuthToken() string        { return p.Token }
 func (p *SpyProviderRepository) MatchesURL(_ string) bool { return false }
 
 func (p *SpyProviderRepository) DiscoverRepositories(
 	_ context.Context, org string,
 ) ([]entities.Repository, error) {
+	p.mu.Lock()
 	p.DiscoveredOrgs = append(p.DiscoveredOrgs, org)
+	p.mu.Unlock()
 	return p.Repositories, p.DiscoverErr
 }
 
@@ -104,14 +112,18 @@ func (p *SpyProviderRepository) HasFile(
 func (p *SpyProviderRepository) CreateBranchWithChanges(
 	_ context.Context, _ entities.Repository, input entities.BranchInput,
 ) error {
+	p.mu.Lock()
 	p.BranchInputs = append(p.BranchInputs, input)
+	p.mu.Unlock()
 	return p.CreateBranchErr
 }
 
 func (p *SpyProviderRepository) CreatePullRequest(
 	_ context.Context, _ entities.Repository, input entities.PullRequestInput,
 ) (*entities.PullRequest, error) {
+	p.mu.Lock()
 	p.PRInputs = append(p.PRInputs, input)
+	p.mu.Unlock()
 	if p.CreatePRErr != nil {
 		return nil, p.CreatePRErr
 	}
@@ -128,7 +140,9 @@ func (p *SpyProviderRepository) CreatePullRequest(
 func (p *SpyProviderRepository) PullRequestExists(
 	_ context.Context, _ entities.Repository, branch string,
 ) (bool, error) {
+	p.mu.Lock()
 	p.PRExistsBranches = append(p.PRExistsBranches, branch)
+	p.mu.Unlock()
 	return p.PRExistsResult, p.PRExistsErr
 }
 
@@ -146,11 +160,11 @@ type DummyProviderRepository struct{}
 
 var _ repositories.ProviderRepository = (*DummyProviderRepository)(nil)
 
-func (d *DummyProviderRepository) Name() string                              { return "dummy" }
-func (d *DummyProviderRepository) MatchesURL(_ string) bool                  { return false }
-func (d *DummyProviderRepository) AuthToken() string                         { return "" }
-func (d *DummyProviderRepository) CloneURL(_ entities.Repository) string                { return "" }
-func (d *DummyProviderRepository) SSHCloneURL(_ entities.Repository, _ string) string   { return "" }
+func (d *DummyProviderRepository) Name() string                                       { return "dummy" }
+func (d *DummyProviderRepository) MatchesURL(_ string) bool                           { return false }
+func (d *DummyProviderRepository) AuthToken() string                                  { return "" }
+func (d *DummyProviderRepository) CloneURL(_ entities.Repository) string              { return "" }
+func (d *DummyProviderRepository) SSHCloneURL(_ entities.Repository, _ string) string { return "" }
 
 func (d *DummyProviderRepository) DiscoverRepositories(
 	_ context.Context, _ string,

--- a/test/infrastructure/repositorydoubles/stub_updater_repository.go
+++ b/test/infrastructure/repositorydoubles/stub_updater_repository.go
@@ -4,13 +4,19 @@ package repositorydoubles //nolint:revive,staticcheck // Test package naming fol
 
 import (
 	"context"
+	"sync"
 
 	"github.com/rios0rios0/autoupdate/internal/domain/entities"
 	"github.com/rios0rios0/autoupdate/internal/domain/repositories"
 )
 
 // SpyUpdaterRepository implements repositories.UpdaterRepository as a configurable spy.
+// The recorder slices are guarded by mu because the run command processes
+// repositories concurrently, so Detect/CreateUpdatePRs may be called from
+// multiple goroutines against the same shared spy.
 type SpyUpdaterRepository struct {
+	mu sync.Mutex
+
 	// --- identity ---
 	UpdaterName string
 
@@ -37,7 +43,9 @@ func (u *SpyUpdaterRepository) Name() string { return u.UpdaterName }
 func (u *SpyUpdaterRepository) Detect(
 	_ context.Context, _ repositories.ProviderRepository, repo entities.Repository,
 ) bool {
+	u.mu.Lock()
 	u.DetectedRepos = append(u.DetectedRepos, repo)
+	u.mu.Unlock()
 	return u.DetectResult
 }
 
@@ -47,7 +55,9 @@ func (u *SpyUpdaterRepository) CreateUpdatePRs(
 	repo entities.Repository,
 	opts entities.UpdateOptions,
 ) ([]entities.PullRequest, error) {
+	u.mu.Lock()
 	u.CreatePRsCalls = append(u.CreatePRsCalls, CreatePRsCall{Repo: repo, Opts: opts})
+	u.mu.Unlock()
 	return u.PRs, u.CreatePRsErr
 }
 


### PR DESCRIPTION
## Summary

`autoupdate run` discovers every repository in each configured organization and processes them **one at a time**. For large organizations this makes a single run grow linearly with the repository count, and on hosted CI runners with a per-job time limit the run can be cancelled before it finishes — the work simply does not fit in the window.

This PR makes repository processing **concurrent** within an organization, using a bounded worker pool, so a run completes in a fraction of the wall-clock time and stays comfortably within typical CI job limits.

## What changed

- **Parallel processing**: `processOrganization` now fans out across repositories with `errgroup` + `SetLimit`, instead of a sequential `for` loop. Repository work is I/O-bound (clone + remote API calls), so this yields a near-linear speedup.
- **Configurable**: new `concurrency` config field and `--concurrency` CLI flag.
  - Precedence: `--concurrency` (CLI) > `concurrency` (config) > built-in default of **4**.
  - Any explicit value below `1` is clamped to `1` (fully sequential), so the previous behavior remains available via `concurrency: 1`.
- **Thread-safety**: the aggregate per-organization counters are guarded by a mutex, and the test doubles (spy provider/updater) were made thread-safe since they are now invoked from multiple goroutines.
- **Dependency**: promoted `golang.org/x/sync` from an indirect to a direct dependency.

## Why it is safe

- Each repository already clones into its **own** temporary directory (`os.MkdirTemp`), so there is no shared working tree between goroutines.
- The shared provider and updater instances are **stateless** (their caches are per-call locals), and the provider is HTTP-client based, which is safe for concurrent use.
- Per-repository failures are still **counted and tolerated** (not propagated), preserving the existing "continue on error" behavior.

## Behavior change

Repositories within an organization are now processed up to **4 at a time by default** (previously 1). Logs from different repositories may therefore interleave, and a run uses more local disk / network at once. Set `concurrency: 1` to restore the old sequential behavior.

## Testing

- `go test -tags unit ./...` — all green
- `go test -tags unit -race ./internal/...` — green (race detector clean on the new fan-out)
- `golangci-lint` (shared pipelines config) — no new findings in the changed files
- Added unit tests: `resolveConcurrency` precedence/clamping, and end-to-end processing of many repositories under parallel, sequential, and config-driven settings.

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?
- [x] Did you run all the code checks? (`go test`)
- [x] Are the tests passing?

🤖 Generated with [Claude Code](https://claude.com/claude-code)