### PR TITLE
chore(bump): bumped version to 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-06-08
+
 ### Added
 
 - added parallel repository processing to `autoupdate run`, configurable via the `concurrency` config field and the `--concurrency` flag, so large organizations finish well within CI time limits


### PR DESCRIPTION
## Summary

Cuts the **0.16.0** release so the parallel repository processing feature (#161) ships in a downloadable binary. Consumers that pull the latest release only get the feature once a tagged release exists — this bump enables that.

MINOR bump (0.15.x → 0.16.0) because #161 adds a new feature (`concurrency` config + `--concurrency` flag, parallel `autoupdate run`).

## Release contents (everything since the last tagged release, 0.15.6)

- **0.16.0** — parallel repository processing in `autoupdate run` (default 4, configurable)
- 0.15.8 — Go `1.26.4` + dependency updates
- 0.15.7 — dependency updates

> Note: `0.15.7` and `0.15.8` were bumped in the changelog but never tagged, so no GitHub releases exist for them. Tagging `0.16.0` after merge will publish a release containing all of the above.

## After merge

Push the `0.16.0` tag so the `delivery > release` CI job builds and publishes the GitHub release (with the `autoupdate-0.16.0-linux-amd64.tar.gz` asset). Downstream cronjob pipelines that download the latest release then pick up parallel processing automatically.

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?
- [x] Did you run all the code checks? (`go test`)
- [x] Are the tests passing?

🤖 Generated with [Claude Code](https://claude.com/claude-code)