### PR TITLE
fix(ci): suppress historical gitleaks false positives and bump to 0.16.1

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -31,3 +31,27 @@ internal/infrastructure/repositories/csharp/csharp_updater_repository.go:Passwor
 internal/infrastructure/repositories/csharp/csharp_updater_repository.go:Password in URL:592
 internal/infrastructure/repositories/csharp/csharp_updater_repository.go:Password in URL:596
 internal/infrastructure/repositories/csharp/csharp_updater_repository.go:Password in URL:600
+
+# 2026-06-09: historical false positives from gitleaks pass 2 (the GitLab-customised ruleset
+# scanning full history). All 14 are the "Password in URL" rule matching git-remote
+# authentication URLs that the code assembles at runtime from variables (an auth-token
+# environment variable and Go string concatenation) plus placeholder tokens in test
+# fixtures -- none are real secrets. The same code is already suppressed above at its
+# current-tree paths; these fingerprints cover the pre-refactor paths in commits 66f4a905
+# (2026-02-07) and 0839817b (2026-02-12) so the unchanged history stops failing the
+# main-branch pipeline. (Comment kept free of literal credential URLs so it does not itself
+# trip the scanner.)
+0839817b71019c9bd820d27a2bfa2dd2a96bf0bb:infrastructure/updater/javascript/local.go:Password in URL:272
+0839817b71019c9bd820d27a2bfa2dd2a96bf0bb:infrastructure/updater/javascript/local.go:Password in URL:276
+0839817b71019c9bd820d27a2bfa2dd2a96bf0bb:infrastructure/updater/python/local.go:Password in URL:257
+0839817b71019c9bd820d27a2bfa2dd2a96bf0bb:infrastructure/updater/python/local.go:Password in URL:261
+0839817b71019c9bd820d27a2bfa2dd2a96bf0bb:infrastructure/updater/javascript/javascript.go:Password in URL:519
+0839817b71019c9bd820d27a2bfa2dd2a96bf0bb:infrastructure/updater/javascript/javascript.go:Password in URL:523
+0839817b71019c9bd820d27a2bfa2dd2a96bf0bb:infrastructure/updater/python/python.go:Password in URL:487
+0839817b71019c9bd820d27a2bfa2dd2a96bf0bb:infrastructure/updater/python/python.go:Password in URL:491
+66f4a905e8d7fdff1c0c91da2429dfcd6d8b2340:infrastructure/provider/github/github.go:Password in URL:366
+66f4a905e8d7fdff1c0c91da2429dfcd6d8b2340:infrastructure/provider/github/github_test.go:Password in URL:124
+66f4a905e8d7fdff1c0c91da2429dfcd6d8b2340:infrastructure/updater/golang/golang.go:Password in URL:318
+66f4a905e8d7fdff1c0c91da2429dfcd6d8b2340:infrastructure/updater/golang/golang.go:Password in URL:323
+66f4a905e8d7fdff1c0c91da2429dfcd6d8b2340:infrastructure/provider/gitlab/gitlab_test.go:Password in URL:114
+66f4a905e8d7fdff1c0c91da2429dfcd6d8b2340:infrastructure/provider/gitlab/gitlab.go:Password in URL:386

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,15 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-06-09
+
 ### Changed
 
 - changed the Go module dependencies to their latest versions
+
+### Fixed
+
+- fixed the `gitleaks` security stage failing on `main` (which blocked releases) by suppressing 14 historical false-positive `Password in URL` findings via `.gitleaksignore` — these are git-remote auth URLs built from variables (`${AUTH_TOKEN}`, string concatenation) and fake test fixtures in pre-refactor commits, not real secrets
 
 ## [0.16.0] - 2026-06-08
 


### PR DESCRIPTION
## Summary

`main` has been failing the `gitleaks` security stage since 2026-06-03, which blocks the release pipeline (`delivery-release` `needs: ['go']`, and the `go` job includes security). That's why 0.16.0 — and the dep bumps before it — never produced a tagged release. This PR clears the blocker and cuts **0.16.1** so everything can finally ship.

## The findings (all false positives)

Gitleaks **pass 2** (the GitLab-customised ruleset, full-history scan on `main`) reports **14 `Password in URL` findings**, all in historical commits at the pre-refactor `infrastructure/...` paths:

- `66f4a905` (2026-02-07) and `0839817b` (2026-02-12)
- They are git-remote auth URLs built from **variables**, not secrets: `${AUTH_TOKEN}` shell interpolation and `"https://x-access-token:" + p.token + "@"` string concatenation
- …plus obviously-fake test fixtures: `ghp_secret123`, `glpat-secret`

The equivalent **current-tree** paths are already suppressed in `.gitleaksignore`; only the historical copies (surfaced when pass 2 started scanning full history) were missing. Pass 1 (working tree) already reports clean.

## The fix

- Added the 14 historical fingerprints to `.gitleaksignore`, with a dated rationale comment (per the secret-hygiene standard for historical false positives).
- **Verified locally**: reran pass 2 (`gitleaks detect --config <gitlab-ruleset>`, full history, 202 commits) with the updated ignore file → **`no leaks found`, exit 0**.

## Versioning

PATCH bump 0.16.0 → **0.16.1**. Tagging `0.16.1` after merge builds a release containing everything since 0.15.6 — the parallel-processing feature (0.16.0), the dep bumps, and this fix.

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?
- [x] Did you run all the code checks? (`go test`)
- [x] Are the tests passing?

🤖 Generated with [Claude Code](https://claude.com/claude-code)