### PR TITLE
chore(bump): bumped version to 0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 When a new release is proposed:
 
-1. Create a new branch `bump/x.x.x` (this isn't a long-lived branch!!!);
-2. The Unreleased section on `CHANGELOG.md` gets a version number and date;
+1. Create a new branch `chore/bump-x.x.x` (this isn't a long-lived branch!!!) — the name prefix matters: the release pipeline only tags merges whose branch is named `chore/bump-`;
+2. The Unreleased section on `CHANGELOG.md` gets a version number and date (AutoBump does this automatically);
 3. Open a Pull Request with the bump version changes targeting the `main` branch;
-4. When the Pull Request is merged, a new Git tag must be created using [GitHub environment](https://github.com/rios0rios0/autoupdate/tags).
+4. When the Pull Request is merged, the release pipeline detects the `chore/bump-x.x.x` branch in the merge commit and automatically creates the Git tag and GitHub release.
 
 Releases to productive environments should run from a tagged version.
 Exceptions are acceptable depending on the circumstances (critical bug fixes that can be cherry-picked, etc.).


### PR DESCRIPTION
## Summary

Triggers the **0.16.1** release tag. 0.16.1 is already cut in `CHANGELOG.md` (merged in #164), `main` is green, but no tag was ever created — because #164 merged from a `bump/0.16.1` branch. The release pipeline (`delivery-release`) only runs when the merge commit message contains **`chore/bump-`**:

```
if: github.event_name == 'push' && github.ref == 'refs/heads/main'
    && contains(github.event.head_commit.message, 'chore/bump-')
```

A `bump/0.16.1` merge commit doesn't match, so tagging was silently skipped (this also explains why 0.16.0 never tagged).

Merging **this** PR from a correctly-named `chore/bump-0.16.1` branch makes the merge commit contain `chore/bump-0.16.1`, so `delivery-release` runs, extracts `0.16.1`, and creates the tag + GitHub release (with `autoupdate-0.16.1-linux-amd64.tar.gz`). That release captures everything since 0.15.6 — the parallel-processing feature, the dependency bumps, and the gitleaks fix.

## Also fixes the root cause

The `CHANGELOG.md` header told contributors to create a `bump/x.x.x` branch, which is exactly what breaks tagging. Corrected it to `chore/bump-x.x.x` and clarified that the pipeline auto-tags on merge.

> **Note:** please merge with a **merge commit** (the repo's default) so the merge message carries the `chore/bump-0.16.1` branch name that the pipeline keys on.

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?
- [x] Did you run all the code checks? (`go test`)
- [x] Are the tests passing?

🤖 Generated with [Claude Code](https://claude.com/claude-code)