### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -119,6 +119,7 @@ Cobra CLI (controllers) -> Commands (domain logic) -> Repositories (ports/adapte
 - Supports multiple providers with organizations and tokens
 - Token resolution: inline values, `${ENV_VAR}` expansion, file paths
 - Updaters can be enabled/disabled with per-updater `auto_complete` and `target_branch`
+- Concurrency: `autoupdate run` processes repos within an org in parallel via `errgroup` (default 4), tuned by the `concurrency` config field or `--concurrency` flag (`< 1` clamps to sequential). `RunCommand` guards shared accumulators with a `sync.Mutex` — keep any new shared state goroutine-safe
 - Repository exclusions:
   - **Global**: `exclude_repos` in user config — right-anchored glob list matched against `<org>/<repo>` (or `<org>/<project>/<repo>` for ADO). Filtered by `filterRepositories` in `RunCommand`; honored in `LocalCommand` when settings load successfully.
   - **Per-repo**: `.autoupdate.yaml` in the target repository's root with `skip: true` (and optional `reason`). Read via `support.LoadLocalRepoConfig` (local mode) and `support.LoadRemoteRepoConfig` (batch mode, fetched through `FileAccessProvider.GetFileContent`). Remote fetch failures fail open so a flaky API does not silently disable all updates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `CLAUDE.md` and `.github/copilot-instructions.md` to document batch-mode concurrency (the `concurrency` config field / `--concurrency` flag and the mutex-guarded shared state in `RunCommand`)
+
 ## [0.16.1] - 2026-06-09
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,10 @@ Auto-discovery searches `.`, `.config`, `configs`, `$HOME`, `$HOME/.config` for 
 - **Global**: `exclude_repos` in user config — right-anchored glob list matched against `<org>/<repo>` (or `<org>/<project>/<repo>` for ADO). Honored in batch mode and in local mode when a config file is loadable.
 - **Per-repo**: `.autoupdate.yaml` in the target repository's root with `skip: true` (and optional `reason`). Checked in both `autoupdate run` (fetched via provider API) and `autoupdate .` (read from disk).
 
+### Batch Mode Concurrency
+
+`autoupdate run` processes repositories within an org in parallel via `errgroup` (default 4), set by the `concurrency` config field or `--concurrency` flag; values `< 1` are clamped to 1 (sequential). `RunCommand` guards its shared accumulators with a `sync.Mutex` — keep new shared state goroutine-safe when editing the per-repo loop.
+
 ## Testing Conventions
 
 - Build tag: `//go:build unit` on every test file


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.