### PR TITLE
fix(pipeline): stopped misdetecting a Go task version as Node.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed the CI/CD pipeline updater misreporting an Azure DevOps `GoTool` version as a Node.js upgrade: the `NodeTool` rule matched the wrong input field (`version` instead of `versionSpec`), so its multi-line pattern bled past the Node.js task and captured a later Go task's `version` (e.g. proposing a Node.js bump for a Go version such as `1.21`). Node.js versions are now read from the `NodeTool` `versionSpec` input, and each Azure DevOps task is scanned in isolation so a language rule can no longer capture a neighbouring task's version field
+
 ## [0.16.2] - 2026-06-18
 
 ### Changed

--- a/internal/infrastructure/repositories/pipeline/pipeline_updater_repository.go
+++ b/internal/infrastructure/repositories/pipeline/pipeline_updater_repository.go
@@ -373,7 +373,7 @@ func findUpgradesInFile(
 	latestVersions map[string]string,
 ) []upgradeTask {
 	rules := rulesForCI(ci)
-	matches := scanFileForVersions(content, filePath, rules)
+	matches := scanForVersions(content, filePath, ci, rules)
 
 	var tasks []upgradeTask
 	for _, match := range matches {
@@ -411,6 +411,58 @@ func classifyFile(path string) ciSystem {
 		return ciAzureDevOps
 	}
 	return ""
+}
+
+// azureTaskDecl matches the start of an Azure DevOps task step (e.g.
+// "  - task: NodeTool@0"). It is used to slice a pipeline file into per-task
+// segments so that a task-scoped, multi-line version pattern can never capture
+// a version field that belongs to a *different* task further down the file.
+var azureTaskDecl = regexp.MustCompile(`(?m)^[ \t]*-[ \t]+task:[ \t]*\S+`)
+
+// scanForVersions dispatches version scanning by CI system. Azure DevOps rules
+// use multi-line `(?s)` patterns that match a task name and then the first
+// matching version field; to keep that match anchored to its own task, Azure
+// content is scanned per task segment. GitHub Actions rules are single-line
+// key matches and need no segmentation.
+func scanForVersions(content, filePath string, ci ciSystem, rules []languageRule) []versionMatch {
+	if ci == ciAzureDevOps {
+		return scanAzureDevOpsForVersions(content, filePath, rules)
+	}
+	return scanFileForVersions(content, filePath, rules)
+}
+
+// scanAzureDevOpsForVersions slices the file into per-task segments and scans
+// each one independently, so a task's version pattern cannot bleed into a
+// neighbouring task's version field.
+func scanAzureDevOpsForVersions(content, filePath string, rules []languageRule) []versionMatch {
+	var matches []versionMatch
+	for _, segment := range splitAzureTaskSegments(content) {
+		matches = append(matches, scanFileForVersions(segment, filePath, rules)...)
+	}
+	return matches
+}
+
+// splitAzureTaskSegments partitions content into contiguous, non-overlapping
+// segments: an optional preamble before the first task (holding non-task keys
+// such as terraformVersion) followed by one segment per task step.
+func splitAzureTaskSegments(content string) []string {
+	locs := azureTaskDecl.FindAllStringIndex(content, -1)
+	if len(locs) == 0 {
+		return []string{content}
+	}
+
+	segments := make([]string, 0, len(locs)+1)
+	if locs[0][0] > 0 {
+		segments = append(segments, content[:locs[0][0]])
+	}
+	for i, loc := range locs {
+		end := len(content)
+		if i+1 < len(locs) {
+			end = locs[i+1][0]
+		}
+		segments = append(segments, content[loc[0]:end])
+	}
+	return segments
 }
 
 // scanFileForVersions applies all language rules and returns matches.
@@ -539,7 +591,11 @@ func azureDevOpsRules() []languageRule {
 		{
 			Language: languageNodeJS,
 			Patterns: []*regexp.Regexp{
-				regexp.MustCompile(`(?s)NodeTool@\d.*?version:\s*'([^']+)'`),
+				// The NodeTool task exposes its version through the "versionSpec"
+				// input, not "version" (which belongs to GoTool). Matching
+				// "version" here let the (?s) pattern bleed past NodeTool and
+				// capture an unrelated task's version field.
+				regexp.MustCompile(`(?s)NodeTool@\d.*?versionSpec:\s*'([^']+)'`),
 			},
 		},
 		{

--- a/internal/infrastructure/repositories/pipeline/pipeline_updater_repository_test.go
+++ b/internal/infrastructure/repositories/pipeline/pipeline_updater_repository_test.go
@@ -192,7 +192,7 @@ jobs:
 		content := `steps:
   - task: NodeTool@0
     inputs:
-      version: '18.0.0'
+      versionSpec: '18.0.0'
 `
 		require.NoError(t, os.WriteFile(adoDir+"/build.yml", []byte(content), 0o644))
 
@@ -211,6 +211,58 @@ jobs:
 		assert.Equal(t, "18.0.0", pipeline.UpgradeTaskCurrentVer(upgrades[0]))
 		assert.Equal(t, "22.0.0", pipeline.UpgradeTaskNewVersion(upgrades[0]))
 		assert.Contains(t, fileContents, "azure-devops/build.yml")
+	})
+
+	t.Run("should not misclassify a Go task version as a Node.js version", func(t *testing.T) {
+		t.Parallel()
+
+		// given a pipeline that installs both Node.js (versionSpec) and Go
+		// (version) in separate tasks. The Node.js task must never absorb the
+		// Go task's version field.
+		root := t.TempDir()
+		content := `steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '18.0.0'
+    displayName: 'Install Node.js'
+  - task: GoTool@0
+    inputs:
+      version: '1.21'
+    displayName: 'Install Go'
+`
+		require.NoError(t, os.WriteFile(root+"/azure-pipelines.yml", []byte(content), 0o644))
+
+		latestVersions := map[string]string{
+			"golang": "1.24.1",
+			"nodejs": "22.0.0",
+		}
+
+		// when
+		upgrades, _ := pipeline.LocalScanAndDetermineUpgrades(
+			t.Context(), root, nil, latestVersions,
+		)
+
+		// then each task is upgraded under its own language, and no Node.js
+		// upgrade ever carries the Go task's "1.21" version.
+		require.Len(t, upgrades, 2)
+		byLanguage := make(map[string]pipeline.UpgradeTask, len(upgrades))
+		for _, up := range upgrades {
+			byLanguage[pipeline.UpgradeTaskLanguage(up)] = up
+			if pipeline.UpgradeTaskLanguage(up) == "nodejs" {
+				assert.NotEqual(t, "1.21", pipeline.UpgradeTaskCurrentVer(up),
+					"the Go task version 1.21 must not be captured as a Node.js version")
+			}
+		}
+
+		golang, hasGo := byLanguage["golang"]
+		require.True(t, hasGo, "expected a golang upgrade")
+		assert.Equal(t, "1.21", pipeline.UpgradeTaskCurrentVer(golang))
+		assert.Equal(t, "1.24", pipeline.UpgradeTaskNewVersion(golang))
+
+		nodejs, hasNode := byLanguage["nodejs"]
+		require.True(t, hasNode, "expected a nodejs upgrade")
+		assert.Equal(t, "18.0.0", pipeline.UpgradeTaskCurrentVer(nodejs))
+		assert.Equal(t, "22.0.0", pipeline.UpgradeTaskNewVersion(nodejs))
 	})
 
 	t.Run("should skip non-pipeline YAML files", func(t *testing.T) {


### PR DESCRIPTION
## Summary

The CI/CD pipeline updater proposed a **Node.js** upgrade for a version that actually belonged to a **Go** task in an Azure DevOps pipeline (e.g. it tried to bump a Go version such as `1.21` to the latest Node.js release).

### Root cause

Two compounding issues in the Azure DevOps scanning rules:

1. The `NodeTool` rule matched the wrong input field — `version` — but `NodeTool` exposes its version through `versionSpec` (only `GoTool` uses `version`). The rule therefore never matched Node's own field.
2. Because the rule uses a multi-line `(?s)` pattern, it then "bled" past the Node.js task and captured the **next** task's `version` field (the `GoTool` one), mislabeling that Go version as `nodejs`.

### Fix

- Node.js versions are now read from the `NodeTool` `versionSpec` input.
- Each Azure DevOps task is scanned in isolation (per-task segmentation), so a language rule can no longer capture a neighbouring task's version field.

### Tests

- Updated the `NodeTool` fixture to use the correct `versionSpec` input.
- Added a regression test with a combined Node.js + Go pipeline asserting each task is upgraded under its own language and the Go version is never captured as `nodejs`. The test fails against the previous code and passes with the fix.

`make lint` reports 0 issues and the full unit suite passes.