### PR TITLE
fix(security): harden directory permissions to owner-only (resolve Semgrep incorrect-default-permission)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 - changed the Go module dependencies to their latest versions
 
+### Security
+
+- hardened directory permissions from `0o750`/`0o755` to owner-only `0o700` in `WriteFileChanges` and its test fixtures, resolving the Semgrep `incorrect-default-permission` CI failures (a directory needs the owner execute bit, so the rule's `0o600` file threshold is documented as inapplicable and suppressed per line)
+
 ## [0.16.8] - 2026-07-14
 
 ### Changed

--- a/internal/infrastructure/repositories/dockerfile/dockerfile_updater_repository_test.go
+++ b/internal/infrastructure/repositories/dockerfile/dockerfile_updater_repository_test.go
@@ -1172,7 +1172,8 @@ func TestLocalScanAllDockerfiles(t *testing.T) {
 		// given
 		tmpDir := t.TempDir()
 		hiddenDir := filepath.Join(tmpDir, ".hidden")
-		require.NoError(t, os.MkdirAll(hiddenDir, 0o750))
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		require.NoError(t, os.MkdirAll(hiddenDir, 0o700))
 		content := "FROM golang:1.25-alpine\n"
 		require.NoError(t, os.WriteFile(filepath.Join(hiddenDir, "Dockerfile"), []byte(content), 0o600))
 
@@ -1206,7 +1207,8 @@ func TestLocalScanAllDockerfiles(t *testing.T) {
 		// given
 		tmpDir := t.TempDir()
 		subDir := filepath.Join(tmpDir, "build")
-		require.NoError(t, os.MkdirAll(subDir, 0o750))
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		require.NoError(t, os.MkdirAll(subDir, 0o700))
 		content := "FROM alpine:3.19\nRUN apk add curl\n"
 		require.NoError(t, os.WriteFile(filepath.Join(subDir, "Dockerfile"), []byte(content), 0o600))
 

--- a/internal/infrastructure/repositories/javascript/lockfile_check_test.go
+++ b/internal/infrastructure/repositories/javascript/lockfile_check_test.go
@@ -39,7 +39,8 @@ func initGitRepo(t *testing.T, dir string, files map[string]string) {
 
 	for path, content := range files {
 		full := filepath.Join(dir, path)
-		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o750))
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o700))
 		require.NoError(t, os.WriteFile(full, []byte(content), 0o600))
 	}
 

--- a/internal/infrastructure/repositories/pipeline/pipeline_updater_repository_test.go
+++ b/internal/infrastructure/repositories/pipeline/pipeline_updater_repository_test.go
@@ -25,7 +25,8 @@ func TestLocalScanAndDetermineUpgrades(t *testing.T) {
 		// given
 		root := t.TempDir()
 		adoDir := root + "/azure-devops"
-		require.NoError(t, os.MkdirAll(adoDir, 0o755))
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		require.NoError(t, os.MkdirAll(adoDir, 0o700))
 
 		content := `steps:
   - task: UsePythonVersion@0
@@ -58,7 +59,8 @@ func TestLocalScanAndDetermineUpgrades(t *testing.T) {
 		// given
 		root := t.TempDir()
 		ghDir := root + "/.github/workflows"
-		require.NoError(t, os.MkdirAll(ghDir, 0o755))
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		require.NoError(t, os.MkdirAll(ghDir, 0o700))
 
 		content := `name: CI
 on: push
@@ -93,7 +95,8 @@ jobs:
 		// given
 		root := t.TempDir()
 		adoDir := root + "/azure-devops"
-		require.NoError(t, os.MkdirAll(adoDir, 0o755))
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		require.NoError(t, os.MkdirAll(adoDir, 0o700))
 
 		content := `steps:
   - script: echo "Hello World"
@@ -122,7 +125,8 @@ jobs:
 		// given
 		root := t.TempDir()
 		adoDir := root + "/azure-devops"
-		require.NoError(t, os.MkdirAll(adoDir, 0o755))
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		require.NoError(t, os.MkdirAll(adoDir, 0o700))
 
 		content := `steps:
   - task: UsePythonVersion@0
@@ -151,7 +155,8 @@ jobs:
 		// given
 		root := t.TempDir()
 		adoDir := root + "/azure-devops"
-		require.NoError(t, os.MkdirAll(adoDir, 0o755))
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		require.NoError(t, os.MkdirAll(adoDir, 0o700))
 
 		pythonContent := `steps:
   - task: UsePythonVersion@0
@@ -187,7 +192,8 @@ jobs:
 		// given
 		root := t.TempDir()
 		adoDir := root + "/azure-devops"
-		require.NoError(t, os.MkdirAll(adoDir, 0o755))
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		require.NoError(t, os.MkdirAll(adoDir, 0o700))
 
 		content := `steps:
   - task: NodeTool@0
@@ -295,7 +301,8 @@ func TestApplyUpdatesLocal(t *testing.T) {
 		// given
 		root := t.TempDir()
 		adoDir := root + "/azure-devops"
-		require.NoError(t, os.MkdirAll(adoDir, 0o755))
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		require.NoError(t, os.MkdirAll(adoDir, 0o700))
 
 		content := `steps:
   - script: echo "Hello"

--- a/internal/support/filesystem.go
+++ b/internal/support/filesystem.go
@@ -72,8 +72,8 @@ func WriteFileChanges(rootDir string, changes []entities.FileChange) error {
 	for _, c := range changes {
 		fullPath := filepath.Join(rootDir, c.Path)
 		dir := filepath.Dir(fullPath)
-		// Parent dir for a file written 0o600 below; a directory needs the owner execute
-		// bit, so 0o700 (not the rule's 0o600 file threshold) is the least-privilege mode.
+		// A directory needs the owner execute (search) bit, so 0o700 (not the rule's 0o600
+		// file threshold) is the least-privilege mode; owner-only access is sufficient here.
 		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
 		if err := os.MkdirAll(dir, 0o700); err != nil {
 			return fmt.Errorf("failed to create directory for %s: %w", c.Path, err)

--- a/internal/support/filesystem.go
+++ b/internal/support/filesystem.go
@@ -72,7 +72,10 @@ func WriteFileChanges(rootDir string, changes []entities.FileChange) error {
 	for _, c := range changes {
 		fullPath := filepath.Join(rootDir, c.Path)
 		dir := filepath.Dir(fullPath)
-		if err := os.MkdirAll(dir, 0o750); err != nil {
+		// Parent dir for a file written 0o600 below; a directory needs the owner execute
+		// bit, so 0o700 (not the rule's 0o600 file threshold) is the least-privilege mode.
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		if err := os.MkdirAll(dir, 0o700); err != nil {
 			return fmt.Errorf("failed to create directory for %s: %w", c.Path, err)
 		}
 		if err := os.WriteFile(fullPath, []byte(c.Content), 0o600); err != nil {

--- a/internal/support/filesystem_test.go
+++ b/internal/support/filesystem_test.go
@@ -81,7 +81,8 @@ func TestWalkFilesByExtension(t *testing.T) {
 		root := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(root, "main.tf"), []byte(""), 0o600))
 		require.NoError(t, os.WriteFile(filepath.Join(root, "other.go"), []byte(""), 0o600))
-		require.NoError(t, os.MkdirAll(filepath.Join(root, "modules"), 0o750))
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		require.NoError(t, os.MkdirAll(filepath.Join(root, "modules"), 0o700))
 		require.NoError(t, os.WriteFile(filepath.Join(root, "modules", "vpc.tf"), []byte(""), 0o600))
 
 		// when
@@ -99,7 +100,8 @@ func TestWalkFilesByExtension(t *testing.T) {
 
 		// given
 		root := t.TempDir()
-		require.NoError(t, os.MkdirAll(filepath.Join(root, ".git"), 0o750))
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		require.NoError(t, os.MkdirAll(filepath.Join(root, ".git"), 0o700))
 		require.NoError(t, os.WriteFile(filepath.Join(root, ".git", "config.tf"), []byte(""), 0o600))
 		require.NoError(t, os.WriteFile(filepath.Join(root, "main.tf"), []byte(""), 0o600))
 
@@ -172,7 +174,8 @@ func TestWalkFilesByPredicate(t *testing.T) {
 
 		// given
 		root := t.TempDir()
-		require.NoError(t, os.MkdirAll(filepath.Join(root, ".hidden"), 0o750))
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		require.NoError(t, os.MkdirAll(filepath.Join(root, ".hidden"), 0o700))
 		require.NoError(t, os.WriteFile(filepath.Join(root, ".hidden", "Dockerfile"), []byte(""), 0o600))
 		require.NoError(t, os.WriteFile(filepath.Join(root, "Dockerfile"), []byte(""), 0o600))
 


### PR DESCRIPTION
## Problem

CI `sast:semgrep` fails on `main` with 14 blocking findings, all of the same rule:

```
go.lang.correctness.permissions.file_permission.incorrect-default-permission
```

The rule (a gosec G301/G302 port, CWE-276) flags `os.Chmod/Mkdir/OpenFile/MkdirAll/ioutil.WriteFile` whenever the mode is **strictly greater than `0o600`**.

## Root cause

Every finding is an `os.MkdirAll(...)` **directory** creation at `0o750` or `0o755`:

- `internal/support/filesystem.go` (production, `WriteFileChanges`)
- 4 test files creating temp fixture directories

Two facts drive the fix:

1. A directory that is group/world-readable (`0o750`/`0o755`) is broader than these paths need — they are only ever accessed by the owning process. Tightening to `0o700` is a genuine least-privilege improvement.
2. A directory must keep the owner *execute* (search) bit or files cannot be created/read inside it (`0o600` dir ⇒ `permission denied`). So the rule's `0o600` threshold — correct for files — cannot be met by a working directory; `0o700` is the least-privilege mode.

## Fix

- **Hardened** every flagged `os.MkdirAll` from `0o750`/`0o755` to owner-only **`0o700`** (real reduction of group/world access). The production `WriteFileChanges` already writes the file itself `0o600`.
- For the irreducible residual (`0o700` still trips the rule's file-oriented threshold), added a **rule-scoped** `// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission`. The production site carries an inline rationale; the rule stays active elsewhere.
- `CHANGELOG.md` updated under `[Unreleased] > Security`.

Verified locally: `golangci-lint` (pipelines config) → 0 issues; `go build ./...` OK; `gofmt` clean; the directive suppresses all findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)