### PR TITLE
fix(golang): verified golang Docker base image tags exist before bumping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed the Go updater writing non-existent Docker base image tags into `Dockerfile` `FROM` clauses: it now verifies each target `golang:<version>` tag is published on Docker Hub before rewriting, falls back to the closest published patch within the same minor and suffix, and leaves the clause untouched when no suitable image exists — instead of blindly applying the latest `go.dev` version via `sed`, which could point `FROM` at an unpublished patch (registry lag) or a dropped Alpine variant such as `golang:1.25.7-alpine3.20`
+
 ## [0.16.9] - 2026-07-16
 
 ### Changed

--- a/internal/infrastructure/repositories/golang/dockerfile_tags.go
+++ b/internal/infrastructure/repositories/golang/dockerfile_tags.go
@@ -1,0 +1,284 @@
+package golang
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+
+	logger "github.com/sirupsen/logrus"
+	"golang.org/x/mod/semver"
+
+	"github.com/rios0rios0/autoupdate/internal/domain/entities"
+	"github.com/rios0rios0/autoupdate/internal/support"
+)
+
+const (
+	dockerHubTimeout      = 15 * time.Second
+	dockerHubMaxPages     = 5   // fetch up to 5 pages of tags (500 tags)
+	dockerHubPageSize     = 100 // Docker Hub max page size
+	golangImage           = "golang"
+	golangVersionMinParts = 3 // MAJOR.MINOR.PATCH after padding
+)
+
+// golangFromPattern matches the tag of an official `golang` base image in a
+// Dockerfile FROM clause, e.g. `FROM golang:1.24-alpine`. Group 1 is the
+// literal prefix up to and including `golang:`; group 2 is the tag. Only the
+// official Docker Hub `golang` image is matched — a registry- or namespace-
+// qualified `.../golang:` is intentionally excluded because its tags cannot be
+// verified against Docker Hub's `library` namespace.
+var golangFromPattern = regexp.MustCompile(
+	`(?im)^(FROM\s+(?:--platform=\S+\s+)?golang:)([A-Za-z0-9][A-Za-z0-9._-]*)`,
+)
+
+// golangVersionPattern splits a golang tag into its leading version and the
+// remaining suffix, e.g. `1.24.5-alpine3.20` -> (`1.24.5`, `-alpine3.20`).
+var golangVersionPattern = regexp.MustCompile(`^(\d+(?:\.\d+)*)(.*)$`)
+
+// golangTagLister returns the published `golang` tags from a registry. It is a
+// function type so callers inject the Docker Hub adapter and tests inject a
+// hand-rolled lister without touching global state.
+type golangTagLister func(ctx context.Context) ([]string, error)
+
+// updateDockerfileGolangTags scans every Dockerfile under repoDir and rewrites
+// each official `golang:` base image to the tag matching goVersion — but only
+// after verifying that tag actually exists on Docker Hub. When the exact
+// `goVersion`+suffix image is not published (registry lag, or a dropped Alpine
+// variant such as `golang:1.25.7-alpine3.20`), it falls back to the closest
+// existing patch within the same minor+suffix; when nothing suitable exists it
+// leaves the clause untouched so the build is never pointed at a non-existent
+// image. Returns whether any file was changed.
+func updateDockerfileGolangTags(
+	ctx context.Context,
+	repoDir, goVersion string,
+	listTags golangTagLister,
+) (bool, error) {
+	files, err := support.WalkFilesByPredicate(repoDir, isDockerfileName)
+	if err != nil {
+		return false, fmt.Errorf("failed to walk Dockerfiles: %w", err)
+	}
+
+	var available []string
+	fetched := false
+	var changes []entities.FileChange
+
+	for _, rel := range files {
+		data, readErr := os.ReadFile(filepath.Join(repoDir, rel))
+		if readErr != nil {
+			logger.Warnf("[golang] Failed to read %s: %v", rel, readErr)
+			continue
+		}
+		content := string(data)
+		if !golangFromPattern.MatchString(content) {
+			continue
+		}
+
+		// Fetch the tag list lazily — only when a Dockerfile actually
+		// references the official golang image.
+		if !fetched {
+			available, err = listTags(ctx)
+			if err != nil {
+				return false, fmt.Errorf("failed to fetch golang tags: %w", err)
+			}
+			fetched = true
+		}
+
+		if updated := rewriteGolangTags(content, goVersion, available, rel); updated != content {
+			changes = append(changes, entities.FileChange{
+				Path:       rel,
+				Content:    updated,
+				ChangeType: "edit",
+			})
+		}
+	}
+
+	if len(changes) == 0 {
+		return false, nil
+	}
+
+	if writeErr := support.WriteFileChanges(repoDir, changes); writeErr != nil {
+		return false, writeErr
+	}
+	return true, nil
+}
+
+// rewriteGolangTags replaces every official `golang:` tag in content with the
+// closest published tag for goVersion, preserving the original suffix and never
+// downgrading. Clauses whose target image does not exist are left untouched.
+func rewriteGolangTags(content, goVersion string, available []string, relPath string) string {
+	return golangFromPattern.ReplaceAllStringFunc(content, func(match string) string {
+		groups := golangFromPattern.FindStringSubmatch(match)
+		prefix, currentTag := groups[1], groups[2]
+
+		currentVersion, suffix, ok := parseGolangTag(currentTag)
+		if !ok {
+			return match // not a pinned numeric tag (e.g. "latest", "alpine")
+		}
+
+		newTag, resolved := resolveClosestGolangTag(available, goVersion, suffix)
+		if !resolved {
+			logger.Warnf(
+				"[golang] %s: no published golang image for Go %s with suffix %q; leaving golang:%s unchanged",
+				relPath, goVersion, suffix, currentTag,
+			)
+			return match
+		}
+
+		// Never downgrade: only rewrite when the resolved version is newer than
+		// the version currently pinned in the Dockerfile.
+		newVersion, _, _ := parseGolangTag(newTag)
+		if semver.Compare(normalizeGoVersion(newVersion), normalizeGoVersion(currentVersion)) <= 0 {
+			return match
+		}
+
+		logger.Infof("[golang] %s: upgrading golang:%s -> golang:%s", relPath, currentTag, newTag)
+		return prefix + newTag
+	})
+}
+
+// resolveClosestGolangTag returns the best published golang tag for goVersion
+// while preserving suffix. It prefers the exact `goVersion+suffix` tag; when
+// that image is not published it falls back to the highest published patch in
+// the same minor+suffix that does not exceed goVersion. It returns ("", false)
+// when no suitable published tag exists, signalling the caller to leave the
+// Dockerfile clause unchanged rather than point it at a non-existent image.
+func resolveClosestGolangTag(available []string, goVersion, suffix string) (string, bool) {
+	desired := goVersion + suffix
+	if slices.Contains(available, desired) {
+		return desired, true
+	}
+
+	target := normalizeGoVersion(goVersion)
+	targetMinor := semver.MajorMinor(target)
+
+	bestTag := ""
+	bestNorm := ""
+	for _, tag := range available {
+		version, tagSuffix, ok := parseGolangTag(tag)
+		if !ok || tagSuffix != suffix {
+			continue
+		}
+
+		norm := normalizeGoVersion(version)
+		if semver.MajorMinor(norm) != targetMinor {
+			continue // stay within the target minor to avoid cross-version drift
+		}
+		if semver.Compare(norm, target) > 0 {
+			continue // never exceed the target Go version
+		}
+		if bestTag == "" || semver.Compare(norm, bestNorm) > 0 {
+			bestTag, bestNorm = tag, norm
+		}
+	}
+
+	if bestTag != "" {
+		return bestTag, true
+	}
+	return "", false
+}
+
+// parseGolangTag splits a golang tag into its leading version and suffix,
+// returning ok=false when the tag is not version-pinned (e.g. "latest").
+func parseGolangTag(tag string) (string, string, bool) {
+	m := golangVersionPattern.FindStringSubmatch(tag)
+	if len(m) < golangVersionMinParts { // full match + 2 capture groups
+		return "", "", false
+	}
+
+	version, suffix := m[1], m[2]
+	if !semver.IsValid(normalizeGoVersion(version)) {
+		return "", "", false
+	}
+	return version, suffix, true
+}
+
+// normalizeGoVersion turns a bare version like "1.25" into valid semver
+// ("v1.25.0") so golang.org/x/mod/semver can compare it.
+func normalizeGoVersion(version string) string {
+	parts := strings.Split(strings.TrimPrefix(version, "v"), ".")
+	for len(parts) < golangVersionMinParts {
+		parts = append(parts, "0")
+	}
+	return "v" + strings.Join(parts, ".")
+}
+
+// isDockerfileName returns true if a file's base name looks like a Dockerfile.
+func isDockerfileName(name string) bool {
+	return name == "Dockerfile" ||
+		strings.HasPrefix(name, "Dockerfile.") ||
+		strings.HasSuffix(name, ".Dockerfile")
+}
+
+// --- Docker Hub tag fetching ---
+
+type dockerHubTagResult struct {
+	Name string `json:"name"`
+}
+
+type dockerHubTagsResponse struct {
+	Results []dockerHubTagResult `json:"results"`
+	Next    string               `json:"next"`
+}
+
+// fetchGolangTags queries Docker Hub for the published tags of the official
+// `golang` image, paginating through up to dockerHubMaxPages pages.
+func fetchGolangTags(ctx context.Context) ([]string, error) {
+	apiURL := fmt.Sprintf(
+		"https://hub.docker.com/v2/repositories/library/%s/tags/?page_size=%d&ordering=last_updated",
+		golangImage, dockerHubPageSize,
+	)
+
+	client := &http.Client{Timeout: dockerHubTimeout}
+	var tags []string
+
+	for page := 0; page < dockerHubMaxPages && apiURL != ""; page++ {
+		pageTags, next, err := fetchGolangTagPage(ctx, client, apiURL)
+		if err != nil {
+			return nil, err
+		}
+		tags = append(tags, pageTags...)
+		apiURL = next
+	}
+
+	return tags, nil
+}
+
+// fetchGolangTagPage fetches a single page of golang tags from Docker Hub.
+func fetchGolangTagPage(
+	ctx context.Context,
+	client *http.Client,
+	apiURL string,
+) ([]string, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to fetch tags: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var body dockerHubTagsResponse
+	if decErr := json.NewDecoder(resp.Body).Decode(&body); decErr != nil {
+		return nil, "", fmt.Errorf("failed to parse tags response: %w", decErr)
+	}
+
+	tags := make([]string, 0, len(body.Results))
+	for _, result := range body.Results {
+		tags = append(tags, result.Name)
+	}
+
+	return tags, body.Next, nil
+}

--- a/internal/infrastructure/repositories/golang/dockerfile_tags.go
+++ b/internal/infrastructure/repositories/golang/dockerfile_tags.go
@@ -29,12 +29,13 @@ const (
 
 // golangFromPattern matches the tag of an official `golang` base image in a
 // Dockerfile FROM clause, e.g. `FROM golang:1.24-alpine`. Group 1 is the
-// literal prefix up to and including `golang:`; group 2 is the tag. Only the
-// official Docker Hub `golang` image is matched — a registry- or namespace-
-// qualified `.../golang:` is intentionally excluded because its tags cannot be
-// verified against Docker Hub's `library` namespace.
+// literal prefix up to and including `golang:`; group 2 is the tag; group 3 is
+// an optional `@sha256:...` digest. Only the official Docker Hub `golang` image
+// is matched — a registry- or namespace-qualified `.../golang:` is
+// intentionally excluded because its tags cannot be verified against Docker
+// Hub's `library` namespace.
 var golangFromPattern = regexp.MustCompile(
-	`(?im)^(FROM\s+(?:--platform=\S+\s+)?golang:)([A-Za-z0-9][A-Za-z0-9._-]*)`,
+	`(?im)^(FROM\s+(?:--platform=\S+\s+)?golang:)([A-Za-z0-9][A-Za-z0-9._-]*)(@[A-Za-z0-9]+:[A-Za-z0-9]+)?`,
 )
 
 // golangVersionPattern splits a golang tag into its leading version and the
@@ -114,7 +115,14 @@ func updateDockerfileGolangTags(
 func rewriteGolangTags(content, goVersion string, available []string, relPath string) string {
 	return golangFromPattern.ReplaceAllStringFunc(content, func(match string) string {
 		groups := golangFromPattern.FindStringSubmatch(match)
-		prefix, currentTag := groups[1], groups[2]
+		prefix, currentTag, digest := groups[1], groups[2], groups[3]
+
+		// Skip digest-pinned images (`golang:<tag>@sha256:...`): rewriting only
+		// the tag would leave the digest — which pins the exact image — pointing
+		// at a different version, a misleading and effectively no-op change.
+		if digest != "" {
+			return match
+		}
 
 		currentVersion, suffix, ok := parseGolangTag(currentTag)
 		if !ok {
@@ -187,7 +195,7 @@ func resolveClosestGolangTag(available []string, goVersion, suffix string) (stri
 // returning ok=false when the tag is not version-pinned (e.g. "latest").
 func parseGolangTag(tag string) (string, string, bool) {
 	m := golangVersionPattern.FindStringSubmatch(tag)
-	if len(m) < golangVersionMinParts { // full match + 2 capture groups
+	if m == nil { // tag has no leading numeric version (e.g. "latest")
 		return "", "", false
 	}
 

--- a/internal/infrastructure/repositories/golang/dockerfile_tags_test.go
+++ b/internal/infrastructure/repositories/golang/dockerfile_tags_test.go
@@ -228,6 +228,19 @@ func TestRewriteGolangTags(t *testing.T) {
 		assert.Equal(t, content, got)
 	})
 
+	t.Run("should skip digest-pinned images to avoid a tag/digest mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := "FROM golang:1.25.6@sha256:0123456789abcdef AS builder\n"
+
+		// when
+		got := golang.RewriteGolangTags(content, "1.25.7", realisticGolangTags(), "Dockerfile")
+
+		// then
+		assert.Equal(t, content, got)
+	})
+
 	t.Run("should not downgrade when the pin is already newer", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/infrastructure/repositories/golang/dockerfile_tags_test.go
+++ b/internal/infrastructure/repositories/golang/dockerfile_tags_test.go
@@ -1,0 +1,370 @@
+//go:build unit
+
+package golang_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rios0rios0/autoupdate/internal/infrastructure/repositories/golang"
+)
+
+// realisticGolangTags mimics the shape of Docker Hub's `library/golang` tag
+// list at the moment Go 1.25.7 is the latest release. Crucially, the
+// `-alpine3.20` variant was dropped for the 1.25 line (only 1.24.5-alpine3.20
+// remains), which is the exact situation that produced non-existent images.
+func realisticGolangTags() []string {
+	return []string{
+		"latest",
+		"1.25.7", "1.25.6", "1.24.5",
+		"1.25", "1.24",
+		"1.25.7-alpine", "1.25.6-alpine", "1.25-alpine",
+		"1.25.7-alpine3.21", "1.25.6-alpine3.21",
+		"1.25.7-alpine3.22", "1.25.6-alpine3.22",
+		"1.24.5-alpine3.20", // old minor keeps the dropped variant
+		"1.25.7-bookworm", "1.25.6-bookworm",
+	}
+}
+
+func TestResolveClosestGolangTag(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return the exact tag when the target image is published", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		tags := realisticGolangTags()
+
+		// when
+		got, ok := golang.ResolveClosestGolangTag(tags, "1.25.7", "")
+
+		// then
+		require.True(t, ok)
+		assert.Equal(t, "1.25.7", got)
+	})
+
+	t.Run("should preserve the suffix when the exact suffixed image exists", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		tags := realisticGolangTags()
+
+		// when
+		got, ok := golang.ResolveClosestGolangTag(tags, "1.25.7", "-alpine3.21")
+
+		// then
+		require.True(t, ok)
+		assert.Equal(t, "1.25.7-alpine3.21", got)
+	})
+
+	t.Run("should fall back to the closest published patch when the target patch lags", func(t *testing.T) {
+		t.Parallel()
+
+		// given — Docker Hub has not published 1.25.7-alpine3.21 yet
+		tags := []string{"1.25.6-alpine3.21", "1.25.5-alpine3.21", "1.24.9-alpine3.21"}
+
+		// when
+		got, ok := golang.ResolveClosestGolangTag(tags, "1.25.7", "-alpine3.21")
+
+		// then
+		require.True(t, ok)
+		assert.Equal(t, "1.25.6-alpine3.21", got)
+	})
+
+	t.Run("should leave unchanged when the requested Alpine variant was dropped", func(t *testing.T) {
+		t.Parallel()
+
+		// given — no 1.25.*-alpine3.20 exists (the reported bug)
+		tags := realisticGolangTags()
+
+		// when
+		got, ok := golang.ResolveClosestGolangTag(tags, "1.25.7", "-alpine3.20")
+
+		// then
+		assert.False(t, ok)
+		assert.Empty(t, got)
+	})
+
+	t.Run("should not cross the minor boundary when falling back", func(t *testing.T) {
+		t.Parallel()
+
+		// given — only an older minor carries the suffix
+		tags := []string{"1.24.5-alpine3.20", "1.24.4-alpine3.20"}
+
+		// when
+		got, ok := golang.ResolveClosestGolangTag(tags, "1.25.7", "-alpine3.20")
+
+		// then
+		assert.False(t, ok)
+		assert.Empty(t, got)
+	})
+
+	t.Run("should never exceed the target version", func(t *testing.T) {
+		t.Parallel()
+
+		// given — a newer patch than the target exists but must not be chosen
+		tags := []string{"1.25.9", "1.25.8", "1.25.5"}
+
+		// when
+		got, ok := golang.ResolveClosestGolangTag(tags, "1.25.7", "")
+
+		// then
+		require.True(t, ok)
+		assert.Equal(t, "1.25.5", got)
+	})
+
+	t.Run("should return not-found when no published tag matches the suffix", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		tags := []string{"1.25.7", "1.25.7-alpine"}
+
+		// when
+		got, ok := golang.ResolveClosestGolangTag(tags, "1.25.7", "-bookworm")
+
+		// then
+		assert.False(t, ok)
+		assert.Empty(t, got)
+	})
+}
+
+func TestParseGolangTag(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should parse a three-part version", func(t *testing.T) {
+		t.Parallel()
+
+		// when
+		version, suffix, ok := golang.ParseGolangTag("1.25.7")
+
+		// then
+		require.True(t, ok)
+		assert.Equal(t, "1.25.7", version)
+		assert.Empty(t, suffix)
+	})
+
+	t.Run("should split a suffixed version", func(t *testing.T) {
+		t.Parallel()
+
+		// when
+		version, suffix, ok := golang.ParseGolangTag("1.24.5-alpine3.20")
+
+		// then
+		require.True(t, ok)
+		assert.Equal(t, "1.24.5", version)
+		assert.Equal(t, "-alpine3.20", suffix)
+	})
+
+	t.Run("should reject a non-version tag", func(t *testing.T) {
+		t.Parallel()
+
+		// when
+		_, _, ok := golang.ParseGolangTag("latest")
+
+		// then
+		assert.False(t, ok)
+	})
+}
+
+func TestRewriteGolangTags(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should upgrade a plain golang tag to the published target", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := "FROM golang:1.25.6 AS builder\nRUN go build\n"
+
+		// when
+		got := golang.RewriteGolangTags(content, "1.25.7", realisticGolangTags(), "Dockerfile")
+
+		// then
+		assert.Contains(t, got, "FROM golang:1.25.7 AS builder")
+	})
+
+	t.Run("should preserve a suffix and fall back to the closest published patch", func(t *testing.T) {
+		t.Parallel()
+
+		// given — target 1.25.7-alpine3.21 not yet published, only 1.25.6 is
+		content := "FROM golang:1.25.5-alpine3.21\n"
+		tags := []string{"1.25.6-alpine3.21", "1.25.5-alpine3.21"}
+
+		// when
+		got := golang.RewriteGolangTags(content, "1.25.7", tags, "Dockerfile")
+
+		// then
+		assert.Equal(t, "FROM golang:1.25.6-alpine3.21\n", got)
+	})
+
+	t.Run("should leave the clause untouched when the target image does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		// given — dropped Alpine variant: no 1.25.*-alpine3.20 exists
+		content := "FROM golang:1.24.5-alpine3.20 AS builder\n"
+
+		// when
+		got := golang.RewriteGolangTags(content, "1.25.7", realisticGolangTags(), "Dockerfile")
+
+		// then
+		assert.Equal(t, content, got, "must not point FROM at a non-existent image")
+	})
+
+	t.Run("should ignore registry-qualified golang images", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := "FROM ghcr.io/acme/golang:1.25.6\n"
+
+		// when
+		got := golang.RewriteGolangTags(content, "1.25.7", realisticGolangTags(), "Dockerfile")
+
+		// then
+		assert.Equal(t, content, got)
+	})
+
+	t.Run("should not downgrade when the pin is already newer", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := "FROM golang:1.25.7\n"
+
+		// when — target resolves to 1.25.6 only
+		got := golang.RewriteGolangTags(content, "1.25.6", realisticGolangTags(), "Dockerfile")
+
+		// then
+		assert.Equal(t, content, got)
+	})
+
+	t.Run("should honour --platform and lowercase from", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := "from --platform=$BUILDPLATFORM golang:1.25.6-alpine AS build\n"
+
+		// when
+		got := golang.RewriteGolangTags(content, "1.25.7", realisticGolangTags(), "Dockerfile")
+
+		// then
+		assert.Contains(t, got, "golang:1.25.7-alpine")
+		assert.Contains(t, got, "from --platform=$BUILDPLATFORM")
+	})
+}
+
+func TestUpdateDockerfileGolangTags(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should rewrite golang tags across Dockerfiles and report a change", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repoDir := t.TempDir()
+		writeFile(t, repoDir, "Dockerfile", "FROM golang:1.25.6 AS builder\n")
+		writeFile(t, repoDir, "api.Dockerfile", "FROM golang:1.25.6-alpine\n")
+		lister := func(context.Context) ([]string, error) {
+			return realisticGolangTags(), nil
+		}
+
+		// when
+		changed, err := golang.UpdateDockerfileGolangTags(context.Background(), repoDir, "1.25.7", lister)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, changed)
+		assert.Contains(t, readFile(t, repoDir, "Dockerfile"), "golang:1.25.7")
+		assert.Contains(t, readFile(t, repoDir, "api.Dockerfile"), "golang:1.25.7-alpine")
+	})
+
+	t.Run("should not fetch tags when no Dockerfile references golang", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repoDir := t.TempDir()
+		writeFile(t, repoDir, "Dockerfile", "FROM alpine:3.21\nRUN true\n")
+		called := false
+		lister := func(context.Context) ([]string, error) {
+			called = true
+			return nil, errors.New("should not be called")
+		}
+
+		// when
+		changed, err := golang.UpdateDockerfileGolangTags(context.Background(), repoDir, "1.25.7", lister)
+
+		// then
+		require.NoError(t, err)
+		assert.False(t, changed)
+		assert.False(t, called, "tag list must be fetched lazily")
+	})
+
+	t.Run("should leave files untouched when the target image does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		// given — dropped Alpine variant
+		repoDir := t.TempDir()
+		original := "FROM golang:1.24.5-alpine3.20\n"
+		writeFile(t, repoDir, "Dockerfile", original)
+		lister := func(context.Context) ([]string, error) {
+			return realisticGolangTags(), nil
+		}
+
+		// when
+		changed, err := golang.UpdateDockerfileGolangTags(context.Background(), repoDir, "1.25.7", lister)
+
+		// then
+		require.NoError(t, err)
+		assert.False(t, changed)
+		assert.Equal(t, original, readFile(t, repoDir, "Dockerfile"))
+	})
+
+	t.Run("should propagate a tag-fetch error", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repoDir := t.TempDir()
+		writeFile(t, repoDir, "Dockerfile", "FROM golang:1.25.6\n")
+		lister := func(context.Context) ([]string, error) {
+			return nil, errors.New("docker hub unavailable")
+		}
+
+		// when
+		changed, err := golang.UpdateDockerfileGolangTags(context.Background(), repoDir, "1.25.7", lister)
+
+		// then
+		require.Error(t, err)
+		assert.False(t, changed)
+	})
+}
+
+func TestIsDockerfileName(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should recognise Dockerfile name variants", func(t *testing.T) {
+		t.Parallel()
+
+		// given / when / then
+		assert.True(t, golang.IsDockerfileName("Dockerfile"))
+		assert.True(t, golang.IsDockerfileName("Dockerfile.dev"))
+		assert.True(t, golang.IsDockerfileName("api.Dockerfile"))
+		assert.False(t, golang.IsDockerfileName("Makefile"))
+		assert.False(t, golang.IsDockerfileName("dockerfile.txt"))
+	})
+}
+
+// --- helpers ---
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600))
+}
+
+func readFile(t *testing.T, dir, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, name))
+	require.NoError(t, err)
+	return string(data)
+}

--- a/internal/infrastructure/repositories/golang/export_test.go
+++ b/internal/infrastructure/repositories/golang/export_test.go
@@ -49,7 +49,6 @@ func BuildLocalGoScript(providerName string, hasConfigSH bool) string {
 	return buildLocalGoScript(providerName, hasConfigSH)
 }
 
-
 // UpgradeParams is exported for testing.
 type UpgradeParams = upgradeParams
 
@@ -153,4 +152,34 @@ func RunLanguageUpgradeScript(
 	opts LocalUpgradeOptions,
 ) (string, error) {
 	return runLanguageUpgradeScript(ctx, repoDir, vCtx, opts)
+}
+
+// ResolveClosestGolangTag is exported for testing.
+func ResolveClosestGolangTag(available []string, goVersion, suffix string) (string, bool) {
+	return resolveClosestGolangTag(available, goVersion, suffix)
+}
+
+// ParseGolangTag is exported for testing.
+func ParseGolangTag(tag string) (string, string, bool) {
+	return parseGolangTag(tag)
+}
+
+// RewriteGolangTags is exported for testing.
+func RewriteGolangTags(content, goVersion string, available []string, relPath string) string {
+	return rewriteGolangTags(content, goVersion, available, relPath)
+}
+
+// IsDockerfileName is exported for testing.
+func IsDockerfileName(name string) bool {
+	return isDockerfileName(name)
+}
+
+// UpdateDockerfileGolangTags is exported for testing. The tag lister is
+// injected directly so tests avoid shared global state and run in parallel.
+func UpdateDockerfileGolangTags(
+	ctx context.Context,
+	repoDir, goVersion string,
+	listTags func(ctx context.Context) ([]string, error),
+) (bool, error) {
+	return updateDockerfileGolangTags(ctx, repoDir, goVersion, listTags)
 }

--- a/internal/infrastructure/repositories/golang/golang_updater_repository.go
+++ b/internal/infrastructure/repositories/golang/golang_updater_repository.go
@@ -201,6 +201,22 @@ func (u *UpdaterRepository) ApplyUpdates(
 
 	goVersionUpdated := strings.Contains(outputStr, "GO_VERSION_UPDATED=true")
 
+	// Rewrite Dockerfile golang base-image tags in Go, verifying each target
+	// tag exists on Docker Hub (falling back to the closest published one)
+	// instead of blindly writing the go.dev version, which may not have a
+	// published image yet or may lack the requested Alpine variant.
+	if goVersionUpdated {
+		dfChanged, dfErr := updateDockerfileGolangTags(
+			ctx, repoDir, vCtx.LatestVersion, fetchGolangTags,
+		)
+		switch {
+		case dfErr != nil:
+			logger.Warnf("[golang] Failed to update Dockerfile golang image tags: %v", dfErr)
+		case dfChanged:
+			logger.Infof("[golang] Updated Dockerfile golang base image tags to match Go %s", vCtx.LatestVersion)
+		}
+	}
+
 	// Return early if the upgrade script made no filesystem changes
 	if !support.HasUncommittedChanges(ctx, repoDir) {
 		logger.Infof("[golang] No filesystem changes detected after upgrade script")
@@ -297,7 +313,8 @@ func buildLocalGoScript(providerName string, hasConfigSH bool) string {
 	}
 
 	writeGoUpgradeCommands(&sb)
-	writeDockerfileUpdate(&sb)
+	// Dockerfile golang image tags are rewritten in Go (registry-verified) by
+	// updateDockerfileGolangTags after this script runs — see ApplyUpdates.
 
 	return sb.String()
 }
@@ -633,8 +650,10 @@ func buildUpgradeScript(
 	// Go upgrade commands
 	writeGoUpgradeCommands(&sb)
 
-	// Update Dockerfile golang image tags (only when version was bumped)
-	writeDockerfileUpdate(&sb)
+	// NOTE: Dockerfile golang image tags are no longer rewritten from bash.
+	// This monolithic clone-and-push flow is legacy (the golang updater
+	// implements LocalUpdater, so ApplyUpdates handles live runs and performs
+	// the registry-verified Dockerfile rewrite in Go).
 
 	// Overwrite CHANGELOG.md with the pre-generated content (if provided)
 	writeChangelogUpdate(&sb)
@@ -726,26 +745,6 @@ func writeGoUpgradeCommands(sb *strings.Builder) {
 	sb.WriteString("if [ -d \"vendor\" ]; then\n")
 	sb.WriteString("    echo \"Running go mod vendor...\"\n")
 	sb.WriteString("    \"$GO_BINARY\" mod vendor 2>&1 || echo \"WARNING: go mod vendor had some errors\"\n")
-	sb.WriteString("fi\n\n")
-}
-
-func writeDockerfileUpdate(sb *strings.Builder) {
-	sb.WriteString("# Update Dockerfile golang image tags when the Go version was bumped.\n")
-	sb.WriteString("# Uses -print0 / read -d '' to handle paths with spaces or special characters.\n")
-	sb.WriteString("if [ \"$GO_VERSION_CHANGED\" = \"true\" ]; then\n")
-	sb.WriteString("    echo \"Updating Dockerfile golang image tags to $GO_VERSION...\"\n")
-	sb.WriteString(
-		"    find . -type f -not -path './.git/*' " +
-			"\\( -name 'Dockerfile' -o -name 'Dockerfile.*' -o -name '*.Dockerfile' \\) " +
-			"-print0 | while IFS= read -r -d '' df; do\n",
-	)
-	sb.WriteString("        if grep -q 'golang:[0-9]' \"$df\"; then\n")
-	sb.WriteString(
-		"            sed \"s|golang:[0-9][0-9.]*|golang:${GO_VERSION}|g\" \"$df\" > \"$df.tmp\" && mv \"$df.tmp\" \"$df\"\n",
-	)
-	sb.WriteString("            echo \"  Updated $df\"\n")
-	sb.WriteString("        fi\n")
-	sb.WriteString("    done\n")
 	sb.WriteString("fi\n\n")
 }
 

--- a/internal/infrastructure/repositories/golang/golang_updater_repository.go
+++ b/internal/infrastructure/repositories/golang/golang_updater_repository.go
@@ -213,7 +213,10 @@ func (u *UpdaterRepository) ApplyUpdates(
 		case dfErr != nil:
 			logger.Warnf("[golang] Failed to update Dockerfile golang image tags: %v", dfErr)
 		case dfChanged:
-			logger.Infof("[golang] Updated Dockerfile golang base image tags to match Go %s", vCtx.LatestVersion)
+			logger.Infof(
+				"[golang] Updated Dockerfile golang base image tags to the closest published tags for Go %s",
+				vCtx.LatestVersion,
+			)
 		}
 	}
 

--- a/internal/infrastructure/repositories/golang/golang_updater_repository_test.go
+++ b/internal/infrastructure/repositories/golang/golang_updater_repository_test.go
@@ -516,9 +516,9 @@ func TestOpenPullRequest(t *testing.T) {
 			BranchName:          "chore/upgrade-go-1.25.7",
 		}
 		result := &goUpdater.UpgradeResult{
-			HasChanges:      true,
+			HasChanges:       true,
 			GoVersionUpdated: true,
-			Output:          "",
+			Output:           "",
 		}
 
 		// when
@@ -798,4 +798,3 @@ func TestPrepareLocalChangelogGo(t *testing.T) {
 		assert.Empty(t, result)
 	})
 }
-

--- a/internal/infrastructure/repositories/golang/local.go
+++ b/internal/infrastructure/repositories/golang/local.go
@@ -172,7 +172,10 @@ func executeLocalUpgrade(
 		case dfErr != nil:
 			logger.Warnf("[golang] Failed to update Dockerfile golang image tags: %v", dfErr)
 		case dfChanged:
-			logger.Infof("[golang] Updated Dockerfile golang base image tags to match Go %s", vCtx.LatestVersion)
+			logger.Infof(
+				"[golang] Updated Dockerfile golang base image tags to the closest published tags for Go %s",
+				vCtx.LatestVersion,
+			)
 		}
 	}
 

--- a/internal/infrastructure/repositories/golang/local.go
+++ b/internal/infrastructure/repositories/golang/local.go
@@ -160,6 +160,22 @@ func executeLocalUpgrade(
 
 	goVersionUpdated := strings.Contains(outputStr, "GO_VERSION_UPDATED=true")
 
+	// Rewrite Dockerfile golang base-image tags in Go, verifying each target
+	// tag exists on Docker Hub (falling back to the closest published one)
+	// instead of blindly writing the go.dev version, which may not have a
+	// published image yet or may lack the requested Alpine variant.
+	if goVersionUpdated {
+		dfChanged, dfErr := updateDockerfileGolangTags(
+			ctx, repoDir, vCtx.LatestVersion, fetchGolangTags,
+		)
+		switch {
+		case dfErr != nil:
+			logger.Warnf("[golang] Failed to update Dockerfile golang image tags: %v", dfErr)
+		case dfChanged:
+			logger.Infof("[golang] Updated Dockerfile golang base image tags to match Go %s", vCtx.LatestVersion)
+		}
+	}
+
 	// --- Git Finalize (go-git) ---
 	commitMsg := goCommitMsgDeps
 	if goVersionUpdated {
@@ -290,8 +306,9 @@ func buildLocalUpgradeScript(params localUpgradeParams) string {
 	// Go upgrade commands (reuse existing)
 	writeGoUpgradeCommands(&sb)
 
-	// Update Dockerfile golang image tags (only when version was bumped)
-	writeDockerfileUpdate(&sb)
+	// NOTE: Dockerfile golang image tags are updated in Go (registry-verified)
+	// by updateDockerfileGolangTags after this script runs — never via a blind
+	// tag rewrite here, which could point FROM at a non-existent image.
 
 	// Changelog update (reuse existing)
 	writeChangelogUpdate(&sb)


### PR DESCRIPTION
## Summary

The Go updater rewrote Dockerfile base-image tags with a blind shell substitution (`sed "s|golang:[0-9][0-9.]*|golang:${GO_VERSION}|g"`), writing the latest **go.dev** version into the `FROM` clause **without checking the registry**. This produced non-existent images in two real cases:

- **Registry lag** — go.dev publishes `1.25.7` before Docker Hub builds `golang:1.25.7`.
- **Dropped Alpine variant** — `FROM golang:1.24-alpine3.20` became `golang:1.25.7-alpine3.20`, but Go 1.25.x only ships `-alpine3.21`/`-alpine3.22`, so that image never existed.

## Fix

New `dockerfile_tags.go` performs the rewrite **in Go, registry-verified**:

1. **Check first** — use the exact `golang:<goVersion><suffix>` only if it is published on Docker Hub.
2. **Closest fallback** — otherwise the highest published patch in the *same minor + same suffix* not exceeding the target (handles lag: `1.25.7-alpine3.21` → `1.25.6-alpine3.21`).
3. **Never break** — when nothing suitable exists, leave the `FROM` clause untouched (and log a warning); never downgrade across a minor.

The blind `writeDockerfileUpdate` bash was removed from all three script builders (function deleted), and `updateDockerfileGolangTags` was wired into the two live flows — `ApplyUpdates` (batch `autoupdate run`) and `executeLocalUpgrade` (`autoupdate .`). The tag lister is injected as a parameter (clean DI, no global state).

## Verification

- `make lint` → 0 issues · `make test` → pass · `make sast` → 0 findings (Semgrep / Trivy / Gitleaks)
- `go vet` clean; full suite green under `-race`
- New BDD unit tests: exact match, lag patch-fallback, alpine-drop leave-unchanged, suffix preservation, no-downgrade, `--platform`/lowercase `from`, registry-qualified exclusion, lazy fetch, error propagation

## Notes

- The sibling `dockerfile` updater already only writes tags it fetched from Docker Hub, so it was left untouched.
- The same latent pattern exists in the `python`, `javascript`, `java`, `ruby`, and `csharp` updaters (each blind-`sed`s its own base image). Kept out of scope here to stay focused; a clean follow-up.
- The rewrite now targets only `FROM` lines (not `golang:` inside `COPY --from=` or comments), which is safer than the old global `sed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)