### PR TITLE
feat(golang): supported nested Go modules in subdirectories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,15 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Added
 
-- added nested Go module support to the Go updater: it now discovers every `go.mod` in a repository instead of only the one at the root, and applies the `go` directive bump, `go get -u -t ./...` and `go mod tidy` inside each module directory — `go get ./...` never crosses a module boundary, so a repository that keeps a Go module in a subdirectory (for example an integration-test harness living inside an infrastructure repository) had that module left permanently outdated; vendored, `testdata`, `node_modules` and hidden directories are skipped so their pinned manifests are not rewritten
+- added nested Go module support to the Go updater: it now discovers every `go.mod` in a repository instead of only the one at the root, and applies the `go` directive bump, `go get -u -t ./...` and `go mod tidy` inside each module directory — `go get ./...` never crosses a module boundary, so a repository that keeps a Go module in a subdirectory (for example an integration-test harness living inside an infrastructure repository) had that module left permanently outdated; vendored, `testdata`, `node_modules` and hidden directories are skipped so their pinned manifests are not rewritten; whether a run counts as a Go version upgrade is now decided across every module rather than from the root alone, so a stale nested module no longer produces a PR whose title and changelog entry contradict each other
 
 ### Fixed
 
 - fixed Go ecosystem detection skipping any repository whose only `go.mod` lives in a subdirectory: detection previously asked the provider for a root `go.mod` alone, so such repositories were never processed by the Go updater at all; the version context that drives the branch name and changelog wording now falls back to the first nested module when the root declares no module
+- fixed the Go upgrade script aborting midway when a `go.mod` declares no `go` directive: `grep` exits non-zero on no match, which under `set -o pipefail` killed the run and left the modules already processed half-upgraded — the reads now tolerate a missing directive, which also makes the existing "no directive" branch reachable
+- fixed the Go version being dropped from the generated commit subject: the backticks around `$GO_VERSION` were unescaped, so bash expanded them as command substitution and committed `upgraded Go version to  and updated all dependencies`
+- fixed the Go updater failing on a module directory whose name starts with `-`, which bash parsed as a `pushd` stack-index option
+- fixed the Go updater treating the repository root as a nested module on Azure DevOps, whose API returns absolute item paths (`/go.mod`) rather than repo-relative ones
 - fixed the Go updater writing non-existent Docker base image tags into `Dockerfile` `FROM` clauses: it now verifies each target `golang:<version>` tag is published on Docker Hub before rewriting, falls back to the closest published patch within the same minor and suffix, and leaves the clause untouched when no suitable image exists — instead of blindly applying the latest `go.dev` version via `sed`, which could point `FROM` at an unpublished patch (registry lag) or a dropped Alpine variant such as `golang:1.25.7-alpine3.20`
 
 ## [0.16.9] - 2026-07-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,13 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added nested Go module support to the Go updater: it now discovers every `go.mod` in a repository instead of only the one at the root, and applies the `go` directive bump, `go get -u -t ./...` and `go mod tidy` inside each module directory — `go get ./...` never crosses a module boundary, so a repository that keeps a Go module in a subdirectory (for example an integration-test harness living inside an infrastructure repository) had that module left permanently outdated; vendored, `testdata`, `node_modules` and hidden directories are skipped so their pinned manifests are not rewritten
+
 ### Fixed
 
+- fixed Go ecosystem detection skipping any repository whose only `go.mod` lives in a subdirectory: detection previously asked the provider for a root `go.mod` alone, so such repositories were never processed by the Go updater at all; the version context that drives the branch name and changelog wording now falls back to the first nested module when the root declares no module
 - fixed the Go updater writing non-existent Docker base image tags into `Dockerfile` `FROM` clauses: it now verifies each target `golang:<version>` tag is published on Docker Hub before rewriting, falls back to the closest published patch within the same minor and suffix, and leaves the clause untouched when no suitable image exists — instead of blindly applying the latest `go.dev` version via `sed`, which could point `FROM` at an unpublished patch (registry lag) or a dropped Alpine variant such as `golang:1.25.7-alpine3.20`
 
 ## [0.16.9] - 2026-07-16

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A self-hosted Dependabot alternative that automatically discovers repositories, 
 | Ecosystem | What it does                                                               |
 |-----------|----------------------------------------------------------------------------|
 | Terraform | Detects Git-based module sources with `?ref=` tags, upgrades to latest tag |
-| Go        | Upgrades Go version in `go.mod`, runs `go get -u -t ./...` and `go mod tidy` |
+| Go        | Upgrades the Go version in every `go.mod` (root and nested modules), running `go get -u -t ./...` and `go mod tidy` in each |
 
 ## Installation
 

--- a/internal/infrastructure/repositories/golang/export_test.go
+++ b/internal/infrastructure/repositories/golang/export_test.go
@@ -40,12 +40,18 @@ func GoModPathFor(dir string) string {
 	return goModPathFor(dir)
 }
 
-// ResolveCurrentGoDirective is exported for testing.
-func ResolveCurrentGoDirective(
+// ResolveVersionUpgradeNeed is exported for testing.
+func ResolveVersionUpgradeNeed(
 	read func(dir string) (string, error),
-	nestedDirs func() []string,
-) (string, string, bool) {
-	return resolveCurrentGoDirective(read, nestedDirs)
+	moduleDirs func() []string,
+	targetVersion string,
+) (bool, string, bool) {
+	return resolveVersionUpgradeNeed(read, moduleDirs, targetVersion)
+}
+
+// WriteCommitAndPush is exported for testing.
+func WriteCommitAndPush(sb *strings.Builder) {
+	writeCommitAndPush(sb)
 }
 
 // WriteGoUpgradeCommands is exported for testing.

--- a/internal/infrastructure/repositories/golang/export_test.go
+++ b/internal/infrastructure/repositories/golang/export_test.go
@@ -16,6 +16,43 @@ func ParseGoDirective(content string) string {
 	return parseGoDirective(content)
 }
 
+// ModuleDirsFromPaths is exported for testing.
+func ModuleDirsFromPaths(paths []string) []string {
+	return moduleDirsFromPaths(paths)
+}
+
+// DiscoverLocalModuleDirs is exported for testing.
+func DiscoverLocalModuleDirs(repoDir string) []string {
+	return discoverLocalModuleDirs(repoDir)
+}
+
+// DiscoverRemoteModuleDirs is exported for testing.
+func DiscoverRemoteModuleDirs(
+	ctx context.Context,
+	provider repositories.ProviderRepository,
+	repo entities.Repository,
+) []string {
+	return discoverRemoteModuleDirs(ctx, provider, repo)
+}
+
+// GoModPathFor is exported for testing.
+func GoModPathFor(dir string) string {
+	return goModPathFor(dir)
+}
+
+// ResolveCurrentGoDirective is exported for testing.
+func ResolveCurrentGoDirective(
+	read func(dir string) (string, error),
+	nestedDirs func() []string,
+) (string, string, bool) {
+	return resolveCurrentGoDirective(read, nestedDirs)
+}
+
+// WriteGoUpgradeCommands is exported for testing.
+func WriteGoUpgradeCommands(sb *strings.Builder) {
+	writeGoUpgradeCommands(sb)
+}
+
 // ResolveVersionContext is exported for testing.
 func ResolveVersionContext(
 	ctx context.Context,

--- a/internal/infrastructure/repositories/golang/golang_updater_repository.go
+++ b/internal/infrastructure/repositories/golang/golang_updater_repository.go
@@ -71,6 +71,10 @@ func NewUpdaterRepositoryWithDeps(vf VersionFetcher) repositories.UpdaterReposit
 func (u *UpdaterRepository) Name() string { return updaterName }
 
 // Detect returns true if the repository has Go marker files (e.g. go.mod).
+// The langforge detector only inspects the repository root, so a repository
+// that keeps its module in a subdirectory — such as a Terraform or
+// infrastructure repository with a Go test harness nested under it — is
+// detected through a full listing of go.mod files instead.
 func (u *UpdaterRepository) Detect(
 	ctx context.Context,
 	provider repositories.ProviderRepository,
@@ -79,9 +83,21 @@ func (u *UpdaterRepository) Detect(
 	found, err := support.DetectRemote(ctx, &langGolang.Detector{}, provider, repo)
 	if err != nil {
 		logger.Warnf("[golang] detection error for %s/%s: %v", repo.Organization, repo.Name, err)
+	}
+	if found {
+		return true
+	}
+
+	moduleDirs := discoverRemoteModuleDirs(ctx, provider, repo)
+	if len(moduleDirs) == 0 {
 		return false
 	}
-	return found
+
+	logger.Infof(
+		"[golang] %s/%s has no root go.mod but %d nested module(s): %s",
+		repo.Organization, repo.Name, len(moduleDirs), strings.Join(moduleDirs, ", "),
+	)
+	return true
 }
 
 // CreateUpdatePRs clones the repo, upgrades Go version and
@@ -261,14 +277,18 @@ func (u *UpdaterRepository) ApplyUpdates(
 // context instead of using the provider API.
 func localResolveVersionContext(repoDir, latestGoVersion string) *versionContext {
 	needsVersionUpgrade := true
-	goModPath := filepath.Join(repoDir, "go.mod")
-	data, err := os.ReadFile(goModPath)
-	if err != nil {
-		logger.Warnf("[golang] Could not read local go.mod, assuming version upgrade: %v", err)
+	currentGoVersion, sourceDir, found := resolveCurrentGoDirective(
+		localGoModReader(repoDir),
+		func() []string { return discoverLocalModuleDirs(repoDir) },
+	)
+	if !found {
+		logger.Warnf("[golang] Could not read any local go.mod, assuming version upgrade")
 	} else {
-		currentGoVersion := parseGoDirective(string(data))
 		needsVersionUpgrade = currentGoVersion != latestGoVersion
-		logger.Infof("[golang] Current go directive: %s (upgrade needed: %v)", currentGoVersion, needsVersionUpgrade)
+		logger.Infof(
+			"[golang] Current go directive in %s: %s (upgrade needed: %v)",
+			goModPathFor(sourceDir), currentGoVersion, needsVersionUpgrade,
+		)
 	}
 
 	branchName := branchGoDepsFmt
@@ -426,15 +446,23 @@ func resolveVersionContext(
 	latestGoVersion string,
 ) *versionContext {
 	// Read the current go.mod from the remote to decide whether this is a
-	// version upgrade or a deps-only refresh — before cloning.
+	// version upgrade or a deps-only refresh — before cloning. When the root
+	// holds no go.mod the first nested module answers the same question.
 	needsVersionUpgrade := true // safe default when go.mod cannot be read
-	goModContent, goModErr := provider.GetFileContent(ctx, repo, "go.mod")
-	if goModErr != nil {
-		logger.Warnf("[golang] Could not read remote go.mod, assuming version upgrade: %v", goModErr)
+	currentGoVersion, sourceDir, found := resolveCurrentGoDirective(
+		func(dir string) (string, error) {
+			return provider.GetFileContent(ctx, repo, goModPathFor(dir))
+		},
+		func() []string { return discoverRemoteModuleDirs(ctx, provider, repo) },
+	)
+	if !found {
+		logger.Warnf("[golang] Could not read any remote go.mod, assuming version upgrade")
 	} else {
-		currentGoVersion := parseGoDirective(goModContent)
 		needsVersionUpgrade = currentGoVersion != latestGoVersion
-		logger.Infof("[golang] Current go directive: %s (upgrade needed: %v)", currentGoVersion, needsVersionUpgrade)
+		logger.Infof(
+			"[golang] Current go directive in %s: %s (upgrade needed: %v)",
+			goModPathFor(sourceDir), currentGoVersion, needsVersionUpgrade,
+		)
 	}
 
 	// Choose the branch name pattern based on the kind of change, following
@@ -684,12 +712,62 @@ func writeGitLabAuth(sb *strings.Builder) {
 	sb.WriteString("echo '    insteadOf = https://gitlab.com/' >> \"$TEMP_GITCONFIG\"\n")
 }
 
+// writeGoUpgradeCommands emits the Go upgrade commands for every module in
+// the repository. A repository may declare more than one module — for example
+// an infrastructure repository whose integration-test harness lives in its own
+// module under a subdirectory — and `go get ./...` never crosses a module
+// boundary, so each module has to be upgraded in its own directory.
 func writeGoUpgradeCommands(sb *strings.Builder) {
-	// Read the current go version from go.mod and compare with the target
-	sb.WriteString("# Read current Go version from go.mod\n")
-	sb.WriteString("CURRENT_GO_VERSION=$(grep -m1 '^go ' go.mod | awk '{print $2}')\n")
-	sb.WriteString("echo \"Current Go version in go.mod: ${CURRENT_GO_VERSION:-<not found>}\"\n")
+	writeGoModuleDiscovery(sb)
+
 	sb.WriteString("GO_VERSION_CHANGED=false\n\n")
+
+	// The module list is fed through a heredoc rather than a pipe so the loop
+	// body runs in the current shell and GO_VERSION_CHANGED survives it.
+	sb.WriteString("while IFS= read -r MODULE_DIR; do\n")
+	sb.WriteString("    [ -n \"$MODULE_DIR\" ] || continue\n")
+	sb.WriteString("    echo \"=== Upgrading Go module in ${MODULE_DIR} ===\"\n")
+	sb.WriteString("    pushd \"$MODULE_DIR\" > /dev/null\n\n")
+
+	writeGoModuleUpgradeCommands(sb)
+
+	sb.WriteString("    popd > /dev/null\n")
+	// The delimiter is deliberately unquoted so that GO_MODULE_DIRS expands.
+	sb.WriteString("done <<GO_MODULE_LIST_END\n")
+	sb.WriteString("${GO_MODULE_DIRS}\n")
+	sb.WriteString("GO_MODULE_LIST_END\n\n")
+}
+
+// writeGoModuleDiscovery emits the discovery of every go.mod in the checkout,
+// skipping vendored trees, test fixtures and hidden directories.
+func writeGoModuleDiscovery(sb *strings.Builder) {
+	sb.WriteString("# Discover every Go module in the repository (root and nested).\n")
+	sb.WriteString("# Unreadable subtrees make find exit non-zero; under `set -e` that would\n")
+	sb.WriteString("# abort the whole upgrade, so the pipeline result is deliberately ignored\n")
+	sb.WriteString("# and the modules that were found are still upgraded.\n")
+	sb.WriteString("GO_MODULE_DIRS=$(find . -type f -name go.mod \\\n")
+	sb.WriteString("    -not -path '*/vendor/*' \\\n")
+	sb.WriteString("    -not -path '*/testdata/*' \\\n")
+	sb.WriteString("    -not -path '*/node_modules/*' \\\n")
+	sb.WriteString("    -not -path '*/.*/*' \\\n")
+	sb.WriteString("    -exec dirname {} \\; 2>/dev/null | sed 's|^\\./||' | sort -u || true)\n")
+	sb.WriteString("if [ -z \"$GO_MODULE_DIRS\" ]; then\n")
+	sb.WriteString("    echo \"WARNING: no go.mod found in the repository, nothing to upgrade\"\n")
+	sb.WriteString("    echo \"GO_VERSION_UPDATED=false\"\n")
+	sb.WriteString("    exit 0\n")
+	sb.WriteString("fi\n")
+	sb.WriteString("echo \"Go modules to upgrade:\"\n")
+	sb.WriteString("echo \"$GO_MODULE_DIRS\" | sed 's/^/  - /'\n\n")
+}
+
+// writeGoModuleUpgradeCommands emits the upgrade of a single module. It runs
+// with the working directory already set to that module's directory, so every
+// path stays module-relative.
+func writeGoModuleUpgradeCommands(sb *strings.Builder) {
+	// Read the current go version from go.mod and compare with the target
+	sb.WriteString("    # Read current Go version from go.mod\n")
+	sb.WriteString("    CURRENT_GO_VERSION=$(grep -m1 '^go ' go.mod | awk '{print $2}')\n")
+	sb.WriteString("    echo \"Current Go version in go.mod: ${CURRENT_GO_VERSION:-<not found>}\"\n")
 
 	// Only update the go directive if the versions differ.
 	// Use sed + redirect-and-move instead of "go mod edit -go=" to preserve
@@ -704,51 +782,57 @@ func writeGoUpgradeCommands(sb *strings.Builder) {
 	//   • Missing go directive — warn and let "go mod tidy" insert it later.
 	//   • sed no-op (pattern didn't match) — verify the file was actually
 	//     modified before setting GO_VERSION_CHANGED.
-	sb.WriteString("if [ -z \"$CURRENT_GO_VERSION\" ]; then\n")
-	sb.WriteString("    echo \"WARNING: no go directive found in go.mod, skipping version update\"\n")
-	sb.WriteString("    echo \"GO_VERSION_UPDATED=false\"\n")
-	sb.WriteString("elif [ \"$CURRENT_GO_VERSION\" != \"$GO_VERSION\" ]; then\n")
-	sb.WriteString("    echo \"Updating Go version from $CURRENT_GO_VERSION to $GO_VERSION...\"\n")
-	sb.WriteString("    sed \"s/^go [0-9][0-9.]*$/go ${GO_VERSION}/\" go.mod > go.mod.tmp && mv go.mod.tmp go.mod\n")
-	sb.WriteString("    # Verify the substitution actually took effect\n")
-	sb.WriteString("    UPDATED_VERSION=$(grep -m1 '^go ' go.mod | awk '{print $2}')\n")
-	sb.WriteString("    if [ \"$UPDATED_VERSION\" = \"$GO_VERSION\" ]; then\n")
-	sb.WriteString("        GO_VERSION_CHANGED=true\n")
-	sb.WriteString("        echo \"GO_VERSION_UPDATED=true\"\n")
-	sb.WriteString("    else\n")
-	sb.WriteString("        echo \"WARNING: failed to update go directive (sed pattern did not match)\"\n")
+	sb.WriteString("    if [ -z \"$CURRENT_GO_VERSION\" ]; then\n")
+	sb.WriteString("        echo \"WARNING: no go directive found in go.mod, skipping version update\"\n")
 	sb.WriteString("        echo \"GO_VERSION_UPDATED=false\"\n")
-	sb.WriteString("    fi\n")
-	sb.WriteString("else\n")
-	sb.WriteString("    echo \"Go version already at $GO_VERSION, skipping directive update\"\n")
-	sb.WriteString("    echo \"GO_VERSION_UPDATED=false\"\n")
-	sb.WriteString("fi\n\n")
-
-	sb.WriteString("echo \"Running go get -u -t ./...\"\n")
+	sb.WriteString("    elif [ \"$CURRENT_GO_VERSION\" != \"$GO_VERSION\" ]; then\n")
+	sb.WriteString("        echo \"Updating Go version from $CURRENT_GO_VERSION to $GO_VERSION...\"\n")
 	sb.WriteString(
-		"\"$GO_BINARY\" get -u -t ./... 2>&1 || echo \"WARNING: go get -u -t had some errors (continuing anyway)\"\n\n",
+		"        sed \"s/^go [0-9][0-9.]*$/go ${GO_VERSION}/\" go.mod > go.mod.tmp && mv go.mod.tmp go.mod\n",
+	)
+	sb.WriteString("        # Verify the substitution actually took effect\n")
+	sb.WriteString("        UPDATED_VERSION=$(grep -m1 '^go ' go.mod | awk '{print $2}')\n")
+	sb.WriteString("        if [ \"$UPDATED_VERSION\" = \"$GO_VERSION\" ]; then\n")
+	sb.WriteString("            GO_VERSION_CHANGED=true\n")
+	sb.WriteString("            echo \"GO_VERSION_UPDATED=true\"\n")
+	sb.WriteString("        else\n")
+	sb.WriteString("            echo \"WARNING: failed to update go directive (sed pattern did not match)\"\n")
+	sb.WriteString("            echo \"GO_VERSION_UPDATED=false\"\n")
+	sb.WriteString("        fi\n")
+	sb.WriteString("    else\n")
+	sb.WriteString("        echo \"Go version already at $GO_VERSION, skipping directive update\"\n")
+	sb.WriteString("        echo \"GO_VERSION_UPDATED=false\"\n")
+	sb.WriteString("    fi\n\n")
+
+	sb.WriteString("    echo \"Running go get -u -t ./...\"\n")
+	sb.WriteString(
+		"    \"$GO_BINARY\" get -u -t ./... 2>&1 || " +
+			"echo \"WARNING: go get -u -t had some errors (continuing anyway)\"\n\n",
 	)
 
-	sb.WriteString("echo \"Running go mod tidy...\"\n")
+	sb.WriteString("    echo \"Running go mod tidy...\"\n")
 	sb.WriteString(
-		"\"$GO_BINARY\" mod tidy 2>&1 || echo \"WARNING: go mod tidy had some errors (continuing anyway)\"\n\n",
+		"    \"$GO_BINARY\" mod tidy 2>&1 || " +
+			"echo \"WARNING: go mod tidy had some errors (continuing anyway)\"\n\n",
 	)
 
 	// Re-apply the Go version after go mod tidy, because older Go binaries
 	// may normalise the three-part version back to two-part during tidy.
-	sb.WriteString("# Re-apply Go version if go mod tidy normalised it\n")
-	sb.WriteString("AFTER_TIDY_VERSION=$(grep -m1 '^go ' go.mod | awk '{print $2}')\n")
-	sb.WriteString("if [ -n \"$AFTER_TIDY_VERSION\" ] && [ \"$AFTER_TIDY_VERSION\" != \"$GO_VERSION\" ]; then\n")
-	sb.WriteString("    echo \"Re-applying Go version (go mod tidy changed it to $AFTER_TIDY_VERSION)...\"\n")
+	sb.WriteString("    # Re-apply Go version if go mod tidy normalised it\n")
+	sb.WriteString("    AFTER_TIDY_VERSION=$(grep -m1 '^go ' go.mod | awk '{print $2}')\n")
 	sb.WriteString(
-		"    sed \"s/^go [0-9][0-9.]*$/go ${GO_VERSION}/\" go.mod > go.mod.tmp && mv go.mod.tmp go.mod\n",
+		"    if [ -n \"$AFTER_TIDY_VERSION\" ] && [ \"$AFTER_TIDY_VERSION\" != \"$GO_VERSION\" ]; then\n",
 	)
-	sb.WriteString("fi\n\n")
+	sb.WriteString("        echo \"Re-applying Go version (go mod tidy changed it to $AFTER_TIDY_VERSION)...\"\n")
+	sb.WriteString(
+		"        sed \"s/^go [0-9][0-9.]*$/go ${GO_VERSION}/\" go.mod > go.mod.tmp && mv go.mod.tmp go.mod\n",
+	)
+	sb.WriteString("    fi\n\n")
 
-	sb.WriteString("if [ -d \"vendor\" ]; then\n")
-	sb.WriteString("    echo \"Running go mod vendor...\"\n")
-	sb.WriteString("    \"$GO_BINARY\" mod vendor 2>&1 || echo \"WARNING: go mod vendor had some errors\"\n")
-	sb.WriteString("fi\n\n")
+	sb.WriteString("    if [ -d \"vendor\" ]; then\n")
+	sb.WriteString("        echo \"Running go mod vendor...\"\n")
+	sb.WriteString("        \"$GO_BINARY\" mod vendor 2>&1 || echo \"WARNING: go mod vendor had some errors\"\n")
+	sb.WriteString("    fi\n\n")
 }
 
 func writeChangelogUpdate(sb *strings.Builder) {
@@ -869,10 +953,10 @@ func GenerateGoPRDescription(goVersion string, hasConfigSH, goVersionUpdated boo
 	}
 	sb.WriteString("### Changes\n\n")
 	if goVersionUpdated {
-		sb.WriteString("- Updated `go.mod` Go directive to `" + goVersion + "`\n")
+		sb.WriteString("- Updated the `go` directive to `" + goVersion + "` in every `go.mod`\n")
 	}
-	sb.WriteString("- Ran `go get -u -t ./...` to update all dependencies\n")
-	sb.WriteString("- Ran `go mod tidy` to clean up\n")
+	sb.WriteString("- Ran `go get -u -t ./...` in each module directory to update all dependencies\n")
+	sb.WriteString("- Ran `go mod tidy` in each module directory to clean up\n")
 	if hasConfigSH {
 		sb.WriteString("- `config.sh` was sourced before running Go commands (private package settings)\n")
 	}

--- a/internal/infrastructure/repositories/golang/golang_updater_repository.go
+++ b/internal/infrastructure/repositories/golang/golang_updater_repository.go
@@ -277,17 +277,18 @@ func (u *UpdaterRepository) ApplyUpdates(
 // context instead of using the provider API.
 func localResolveVersionContext(repoDir, latestGoVersion string) *versionContext {
 	needsVersionUpgrade := true
-	currentGoVersion, sourceDir, found := resolveCurrentGoDirective(
+	needsUpgrade, sourceDir, found := resolveVersionUpgradeNeed(
 		localGoModReader(repoDir),
 		func() []string { return discoverLocalModuleDirs(repoDir) },
+		latestGoVersion,
 	)
 	if !found {
 		logger.Warnf("[golang] Could not read any local go.mod, assuming version upgrade")
 	} else {
-		needsVersionUpgrade = currentGoVersion != latestGoVersion
+		needsVersionUpgrade = needsUpgrade
 		logger.Infof(
-			"[golang] Current go directive in %s: %s (upgrade needed: %v)",
-			goModPathFor(sourceDir), currentGoVersion, needsVersionUpgrade,
+			"[golang] Go version upgrade needed: %v (decided by %s)",
+			needsVersionUpgrade, goModPathFor(sourceDir),
 		)
 	}
 
@@ -449,19 +450,20 @@ func resolveVersionContext(
 	// version upgrade or a deps-only refresh — before cloning. When the root
 	// holds no go.mod the first nested module answers the same question.
 	needsVersionUpgrade := true // safe default when go.mod cannot be read
-	currentGoVersion, sourceDir, found := resolveCurrentGoDirective(
+	needsUpgrade, sourceDir, found := resolveVersionUpgradeNeed(
 		func(dir string) (string, error) {
 			return provider.GetFileContent(ctx, repo, goModPathFor(dir))
 		},
 		func() []string { return discoverRemoteModuleDirs(ctx, provider, repo) },
+		latestGoVersion,
 	)
 	if !found {
 		logger.Warnf("[golang] Could not read any remote go.mod, assuming version upgrade")
 	} else {
-		needsVersionUpgrade = currentGoVersion != latestGoVersion
+		needsVersionUpgrade = needsUpgrade
 		logger.Infof(
-			"[golang] Current go directive in %s: %s (upgrade needed: %v)",
-			goModPathFor(sourceDir), currentGoVersion, needsVersionUpgrade,
+			"[golang] Go version upgrade needed: %v (decided by %s)",
+			needsVersionUpgrade, goModPathFor(sourceDir),
 		)
 	}
 
@@ -727,7 +729,9 @@ func writeGoUpgradeCommands(sb *strings.Builder) {
 	sb.WriteString("while IFS= read -r MODULE_DIR; do\n")
 	sb.WriteString("    [ -n \"$MODULE_DIR\" ] || continue\n")
 	sb.WriteString("    echo \"=== Upgrading Go module in ${MODULE_DIR} ===\"\n")
-	sb.WriteString("    pushd \"$MODULE_DIR\" > /dev/null\n\n")
+	// "./" guards against a directory whose name starts with "-", which bash
+	// would otherwise parse as pushd's stack-index option.
+	sb.WriteString("    pushd \"./$MODULE_DIR\" > /dev/null\n\n")
 
 	writeGoModuleUpgradeCommands(sb)
 
@@ -764,9 +768,13 @@ func writeGoModuleDiscovery(sb *strings.Builder) {
 // with the working directory already set to that module's directory, so every
 // path stays module-relative.
 func writeGoModuleUpgradeCommands(sb *strings.Builder) {
-	// Read the current go version from go.mod and compare with the target
+	// Read the current go version from go.mod and compare with the target.
+	// "|| true" is required: a go.mod without a go directive makes grep exit 1,
+	// which under `set -o pipefail` would abort the script and leave the
+	// modules already rewritten in this run only half-upgraded. It also keeps
+	// the "no directive" branch below reachable.
 	sb.WriteString("    # Read current Go version from go.mod\n")
-	sb.WriteString("    CURRENT_GO_VERSION=$(grep -m1 '^go ' go.mod | awk '{print $2}')\n")
+	sb.WriteString("    CURRENT_GO_VERSION=$(grep -m1 '^go ' go.mod | awk '{print $2}' || true)\n")
 	sb.WriteString("    echo \"Current Go version in go.mod: ${CURRENT_GO_VERSION:-<not found>}\"\n")
 
 	// Only update the go directive if the versions differ.
@@ -791,7 +799,7 @@ func writeGoModuleUpgradeCommands(sb *strings.Builder) {
 		"        sed \"s/^go [0-9][0-9.]*$/go ${GO_VERSION}/\" go.mod > go.mod.tmp && mv go.mod.tmp go.mod\n",
 	)
 	sb.WriteString("        # Verify the substitution actually took effect\n")
-	sb.WriteString("        UPDATED_VERSION=$(grep -m1 '^go ' go.mod | awk '{print $2}')\n")
+	sb.WriteString("        UPDATED_VERSION=$(grep -m1 '^go ' go.mod | awk '{print $2}' || true)\n")
 	sb.WriteString("        if [ \"$UPDATED_VERSION\" = \"$GO_VERSION\" ]; then\n")
 	sb.WriteString("            GO_VERSION_CHANGED=true\n")
 	sb.WriteString("            echo \"GO_VERSION_UPDATED=true\"\n")
@@ -819,7 +827,7 @@ func writeGoModuleUpgradeCommands(sb *strings.Builder) {
 	// Re-apply the Go version after go mod tidy, because older Go binaries
 	// may normalise the three-part version back to two-part during tidy.
 	sb.WriteString("    # Re-apply Go version if go mod tidy normalised it\n")
-	sb.WriteString("    AFTER_TIDY_VERSION=$(grep -m1 '^go ' go.mod | awk '{print $2}')\n")
+	sb.WriteString("    AFTER_TIDY_VERSION=$(grep -m1 '^go ' go.mod | awk '{print $2}' || true)\n")
 	sb.WriteString(
 		"    if [ -n \"$AFTER_TIDY_VERSION\" ] && [ \"$AFTER_TIDY_VERSION\" != \"$GO_VERSION\" ]; then\n",
 	)
@@ -853,8 +861,11 @@ func writeCommitAndPush(sb *strings.Builder) {
 	sb.WriteString("    echo \"Changes detected, committing and pushing...\"\n")
 	sb.WriteString("    git add -A\n")
 	sb.WriteString("    if [ \"$GO_VERSION_CHANGED\" = \"true\" ]; then\n")
+	// The backticks must be escaped: unescaped, bash treats them as command
+	// substitution and the version silently vanishes from the commit subject.
 	sb.WriteString(
-		"        git commit -m \"chore(deps): upgraded Go version to `$GO_VERSION` and updated all dependencies\"\n",
+		"        git commit -m \"chore(deps): upgraded Go version to \\`$GO_VERSION\\` " +
+			"and updated all dependencies\"\n",
 	)
 	sb.WriteString("    else\n")
 	sb.WriteString("        git commit -m \"chore(deps): update Go module dependencies\"\n")

--- a/internal/infrastructure/repositories/golang/golang_updater_repository_test.go
+++ b/internal/infrastructure/repositories/golang/golang_updater_repository_test.go
@@ -52,12 +52,46 @@ func TestDetect(t *testing.T) {
 		assert.True(t, detected)
 	})
 
+	t.Run("should return true when the only go.mod is in a subdirectory", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{}).
+			WithFiles([]entities.File{{Path: "tests/harness/go.mod"}}).
+			BuildSpy()
+		repo := entities.Repository{Organization: "org", Name: "repo"}
+
+		// when
+		detected := goUpdater.NewUpdaterRepository().Detect(t.Context(), provider, repo)
+
+		// then
+		assert.True(t, detected)
+	})
+
 	t.Run("should return false when no Go files exist", func(t *testing.T) {
 		t.Parallel()
 
 		// given
 		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
 			WithExistingFiles(map[string]bool{}).
+			BuildSpy()
+		repo := entities.Repository{Organization: "org", Name: "repo"}
+
+		// when
+		detected := goUpdater.NewUpdaterRepository().Detect(t.Context(), provider, repo)
+
+		// then
+		assert.False(t, detected)
+	})
+
+	t.Run("should return false when only a vendored go.mod exists", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{}).
+			WithFiles([]entities.File{{Path: "vendor/example.com/dep/go.mod"}}).
 			BuildSpy()
 		repo := entities.Repository{Organization: "org", Name: "repo"}
 

--- a/internal/infrastructure/repositories/golang/local.go
+++ b/internal/infrastructure/repositories/golang/local.go
@@ -71,16 +71,20 @@ func resolveLocalVersionContext(ctx context.Context, repoDir string) (*versionCo
 	}
 	logger.Infof("[golang] Latest stable Go version: %s", latestGoVersion)
 
-	goModContent, err := os.ReadFile(filepath.Join(repoDir, "go.mod"))
-	if err != nil {
-		return nil, fmt.Errorf("failed to read go.mod: %w", err)
+	// The go directive may live in a nested module when the repository has no
+	// root module, so fall back to the first module found in the checkout.
+	currentGoVersion, sourceDir, found := resolveCurrentGoDirective(
+		localGoModReader(repoDir),
+		func() []string { return discoverLocalModuleDirs(repoDir) },
+	)
+	if !found {
+		return nil, fmt.Errorf("no readable %s found in %s", goModFileName, repoDir)
 	}
 
-	currentGoVersion := parseGoDirective(string(goModContent))
 	needsVersionUpgrade := currentGoVersion != latestGoVersion
 	logger.Infof(
-		"[golang] Current go directive: %s (upgrade needed: %v)",
-		currentGoVersion, needsVersionUpgrade,
+		"[golang] Current go directive in %s: %s (upgrade needed: %v)",
+		goModPathFor(sourceDir), currentGoVersion, needsVersionUpgrade,
 	)
 
 	branchName := branchGoDepsFmt

--- a/internal/infrastructure/repositories/golang/local.go
+++ b/internal/infrastructure/repositories/golang/local.go
@@ -71,20 +71,20 @@ func resolveLocalVersionContext(ctx context.Context, repoDir string) (*versionCo
 	}
 	logger.Infof("[golang] Latest stable Go version: %s", latestGoVersion)
 
-	// The go directive may live in a nested module when the repository has no
-	// root module, so fall back to the first module found in the checkout.
-	currentGoVersion, sourceDir, found := resolveCurrentGoDirective(
+	// Every module counts, not just the root one: the repository may have no
+	// root module at all, and a nested module may be the only stale one.
+	needsVersionUpgrade, sourceDir, found := resolveVersionUpgradeNeed(
 		localGoModReader(repoDir),
 		func() []string { return discoverLocalModuleDirs(repoDir) },
+		latestGoVersion,
 	)
 	if !found {
 		return nil, fmt.Errorf("no readable %s found in %s", goModFileName, repoDir)
 	}
 
-	needsVersionUpgrade := currentGoVersion != latestGoVersion
 	logger.Infof(
-		"[golang] Current go directive in %s: %s (upgrade needed: %v)",
-		goModPathFor(sourceDir), currentGoVersion, needsVersionUpgrade,
+		"[golang] Go version upgrade needed: %v (decided by %s)",
+		needsVersionUpgrade, goModPathFor(sourceDir),
 	)
 
 	branchName := branchGoDepsFmt

--- a/internal/infrastructure/repositories/golang/modules.go
+++ b/internal/infrastructure/repositories/golang/modules.go
@@ -1,0 +1,185 @@
+package golang
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	logger "github.com/sirupsen/logrus"
+
+	"github.com/rios0rios0/autoupdate/internal/domain/entities"
+	"github.com/rios0rios0/autoupdate/internal/domain/repositories"
+	"github.com/rios0rios0/autoupdate/internal/support"
+)
+
+const (
+	// goModFileName is the Go module manifest every module must declare.
+	goModFileName = "go.mod"
+
+	// rootModuleDir is the repo-relative directory of the root module.
+	rootModuleDir = "."
+)
+
+// skippedModuleDirs are directory names that may contain a go.mod which is
+// not a first-class module of the repository: vendored dependencies, Go test
+// fixtures (which intentionally hold broken or pinned manifests), and
+// JavaScript dependencies. Upgrading those would corrupt the tree.
+var skippedModuleDirs = map[string]struct{}{ //nolint:gochecknoglobals // immutable lookup set
+	"vendor":       {},
+	"testdata":     {},
+	"node_modules": {},
+}
+
+// moduleDirsFromPaths converts a list of repo-relative go.mod paths into the
+// sorted, de-duplicated directories that contain them. The root module ("."),
+// when present, always comes first so that it keeps driving the branch name
+// and changelog wording; the remaining modules follow in lexicographic order
+// to make runs deterministic.
+func moduleDirsFromPaths(paths []string) []string {
+	seen := make(map[string]struct{}, len(paths))
+	dirs := make([]string, 0, len(paths))
+
+	for _, p := range paths {
+		normalized := strings.TrimPrefix(path.Clean(strings.ReplaceAll(p, "\\", "/")), "./")
+		if path.Base(normalized) != goModFileName || isSkippedModulePath(normalized) {
+			continue
+		}
+
+		dir := path.Dir(normalized)
+		if _, duplicate := seen[dir]; duplicate {
+			continue
+		}
+		seen[dir] = struct{}{}
+		dirs = append(dirs, dir)
+	}
+
+	sort.Strings(dirs)
+
+	// Pin the root module first regardless of how the other directories sort.
+	if idx := indexOf(dirs, rootModuleDir); idx > 0 {
+		dirs = append([]string{rootModuleDir}, append(dirs[:idx:idx], dirs[idx+1:]...)...)
+	}
+
+	return dirs
+}
+
+// isSkippedModulePath reports whether any segment of the given go.mod path
+// lives inside a vendored, fixture, or hidden directory.
+func isSkippedModulePath(goModPath string) bool {
+	segments := strings.SplitSeq(path.Dir(goModPath), "/")
+	for segment := range segments {
+		if segment == rootModuleDir || segment == "" {
+			continue
+		}
+		if _, skipped := skippedModuleDirs[segment]; skipped {
+			return true
+		}
+		if strings.HasPrefix(segment, ".") {
+			return true
+		}
+	}
+	return false
+}
+
+func indexOf(values []string, target string) int {
+	for i, v := range values {
+		if v == target {
+			return i
+		}
+	}
+	return -1
+}
+
+// goModPathFor returns the repo-relative go.mod path of a module directory.
+func goModPathFor(dir string) string {
+	if dir == "" || dir == rootModuleDir {
+		return goModFileName
+	}
+	return path.Join(dir, goModFileName)
+}
+
+// resolveCurrentGoDirective returns the go directive that drives branch naming
+// and changelog wording, the module directory it was read from, and whether
+// any module could be read at all. The root module is preferred so that
+// single-module repositories keep costing a single lookup; nested modules are
+// only scanned when the root has no go.mod.
+func resolveCurrentGoDirective(
+	read func(dir string) (string, error),
+	nestedDirs func() []string,
+) (string, string, bool) {
+	if content, err := read(rootModuleDir); err == nil {
+		return parseGoDirective(content), rootModuleDir, true
+	}
+
+	for _, dir := range nestedDirs() {
+		if dir == rootModuleDir {
+			continue
+		}
+		content, err := read(dir)
+		if err != nil {
+			continue
+		}
+		return parseGoDirective(content), dir, true
+	}
+
+	return "", "", false
+}
+
+// discoverLocalModuleDirs walks an on-disk repository and returns every
+// directory holding a go.mod, relative to repoDir. A repository whose only
+// module lives in a subdirectory (for example an isolated test-harness module
+// inside an otherwise non-Go repository) yields that subdirectory alone.
+func discoverLocalModuleDirs(repoDir string) []string {
+	paths, err := support.WalkFilesByPredicate(repoDir, func(name string) bool {
+		return name == goModFileName
+	})
+	if err != nil {
+		logger.Warnf("[golang] Failed to scan %s for go.mod files: %v", repoDir, err)
+		return nil
+	}
+
+	return moduleDirsFromPaths(paths)
+}
+
+// localGoModReader returns a reader that resolves module directories against
+// an on-disk repository root.
+func localGoModReader(repoDir string) func(dir string) (string, error) {
+	return func(dir string) (string, error) {
+		data, err := os.ReadFile(filepath.Join(repoDir, filepath.FromSlash(goModPathFor(dir))))
+		if err != nil {
+			return "", fmt.Errorf("failed to read %s: %w", goModPathFor(dir), err)
+		}
+		return string(data), nil
+	}
+}
+
+// discoverRemoteModuleDirs lists the repository's go.mod files through the
+// provider API, so that nested modules are known before anything is cloned.
+func discoverRemoteModuleDirs(
+	ctx context.Context,
+	provider repositories.ProviderRepository,
+	repo entities.Repository,
+) []string {
+	files, err := provider.ListFiles(ctx, repo, goModFileName)
+	if err != nil {
+		logger.Warnf(
+			"[golang] Failed to list go.mod files for %s/%s: %v",
+			repo.Organization, repo.Name, err,
+		)
+		return nil
+	}
+
+	paths := make([]string, 0, len(files))
+	for _, f := range files {
+		if f.IsDir {
+			continue
+		}
+		paths = append(paths, f.Path)
+	}
+
+	return moduleDirsFromPaths(paths)
+}

--- a/internal/infrastructure/repositories/golang/modules.go
+++ b/internal/infrastructure/repositories/golang/modules.go
@@ -44,7 +44,11 @@ func moduleDirsFromPaths(paths []string) []string {
 	dirs := make([]string, 0, len(paths))
 
 	for _, p := range paths {
-		normalized := strings.TrimPrefix(path.Clean(strings.ReplaceAll(p, "\\", "/")), "./")
+		normalized := path.Clean(strings.ReplaceAll(p, "\\", "/"))
+		// Azure DevOps returns absolute item paths ("/go.mod") while GitHub and
+		// GitLab return repo-relative ones; without this the root module would
+		// be recorded as "/" and never recognised as the root.
+		normalized = strings.TrimPrefix(normalized, "/")
 		if path.Base(normalized) != goModFileName || isSkippedModulePath(normalized) {
 			continue
 		}
@@ -102,31 +106,45 @@ func goModPathFor(dir string) string {
 	return path.Join(dir, goModFileName)
 }
 
-// resolveCurrentGoDirective returns the go directive that drives branch naming
-// and changelog wording, the module directory it was read from, and whether
-// any module could be read at all. The root module is preferred so that
-// single-module repositories keep costing a single lookup; nested modules are
-// only scanned when the root has no go.mod.
-func resolveCurrentGoDirective(
+// resolveVersionUpgradeNeed reports whether *any* module in the repository
+// declares a go directive other than targetVersion, the module directory the
+// decision was based on, and whether a module could be read at all.
+//
+// The answer has to span every module because the upgrade runs in every
+// module: deciding from the root alone would label a run "dependencies only"
+// while the script bumps the go directive of a nested module, which then
+// contradicts itself across the branch name, the changelog entry and the PR
+// title. A stale root short-circuits the scan, so the common single-module
+// case still costs one lookup.
+func resolveVersionUpgradeNeed(
 	read func(dir string) (string, error),
-	nestedDirs func() []string,
-) (string, string, bool) {
-	if content, err := read(rootModuleDir); err == nil {
-		return parseGoDirective(content), rootModuleDir, true
+	moduleDirs func() []string,
+	targetVersion string,
+) (bool, string, bool) {
+	rootContent, rootErr := read(rootModuleDir)
+	if rootErr == nil && parseGoDirective(rootContent) != targetVersion {
+		return true, rootModuleDir, true
 	}
 
-	for _, dir := range nestedDirs() {
+	sourceDir, found := rootModuleDir, rootErr == nil
+	for _, dir := range moduleDirs() {
 		if dir == rootModuleDir {
-			continue
+			continue // already read above
 		}
+
 		content, err := read(dir)
 		if err != nil {
 			continue
 		}
-		return parseGoDirective(content), dir, true
+		if !found {
+			sourceDir, found = dir, true
+		}
+		if parseGoDirective(content) != targetVersion {
+			return true, dir, true
+		}
 	}
 
-	return "", "", false
+	return false, sourceDir, found
 }
 
 // discoverLocalModuleDirs walks an on-disk repository and returns every
@@ -138,8 +156,14 @@ func discoverLocalModuleDirs(repoDir string) []string {
 		return name == goModFileName
 	})
 	if err != nil {
-		logger.Warnf("[golang] Failed to scan %s for go.mod files: %v", repoDir, err)
-		return nil
+		// An unreadable subtree aborts the walk with whatever it collected so
+		// far. Discarding that would strand modules that were found and are
+		// perfectly upgradable, so the partial result is kept — matching the
+		// upgrade script, which also tolerates unreadable subtrees.
+		logger.Warnf(
+			"[golang] Scan of %s ended early (%v); continuing with the %d path(s) found",
+			repoDir, err, len(paths),
+		)
 	}
 
 	return moduleDirsFromPaths(paths)

--- a/internal/infrastructure/repositories/golang/modules_test.go
+++ b/internal/infrastructure/repositories/golang/modules_test.go
@@ -1,0 +1,473 @@
+//go:build unit
+
+package golang_test
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rios0rios0/autoupdate/internal/domain/entities"
+	goUpdater "github.com/rios0rios0/autoupdate/internal/infrastructure/repositories/golang"
+	"github.com/rios0rios0/autoupdate/test/infrastructure/repositorydoubles"
+)
+
+// writeModule creates a go.mod with the given directive under repoDir/relDir.
+func writeModule(t *testing.T, repoDir, relDir, goVersion string) {
+	t.Helper()
+
+	dir := filepath.Join(repoDir, filepath.FromSlash(relDir))
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "go.mod"),
+		[]byte("module example.com/"+strings.ReplaceAll(relDir, "/", "-")+"\n\ngo "+goVersion+"\n"),
+		0o600,
+	))
+}
+
+func TestModuleDirsFromPaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return the root module for a repository with only a root go.mod", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		paths := []string{"go.mod"}
+
+		// when
+		dirs := goUpdater.ModuleDirsFromPaths(paths)
+
+		// then
+		assert.Equal(t, []string{"."}, dirs)
+	})
+
+	t.Run("should return the nested directory when the module is not at the root", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		paths := []string{"tests/harness/go.mod"}
+
+		// when
+		dirs := goUpdater.ModuleDirsFromPaths(paths)
+
+		// then
+		assert.Equal(t, []string{"tests/harness"}, dirs)
+	})
+
+	t.Run("should order the root module first and the nested ones lexicographically", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		paths := []string{"tools/go.mod", "go.mod", "examples/basic/go.mod"}
+
+		// when
+		dirs := goUpdater.ModuleDirsFromPaths(paths)
+
+		// then
+		assert.Equal(t, []string{".", "examples/basic", "tools"}, dirs)
+	})
+
+	t.Run("should keep the root module first even when a directory sorts before it", func(t *testing.T) {
+		t.Parallel()
+
+		// given a directory name that sorts before "." in byte order
+		paths := []string{"go.mod", "-tools/go.mod"}
+
+		// when
+		dirs := goUpdater.ModuleDirsFromPaths(paths)
+
+		// then
+		assert.Equal(t, []string{".", "-tools"}, dirs)
+	})
+
+	t.Run("should skip vendored, fixture and hidden modules", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		paths := []string{
+			"go.mod",
+			"vendor/example.com/dep/go.mod",
+			"internal/testdata/broken/go.mod",
+			"web/node_modules/pkg/go.mod",
+			".cache/go.mod",
+		}
+
+		// when
+		dirs := goUpdater.ModuleDirsFromPaths(paths)
+
+		// then
+		assert.Equal(t, []string{"."}, dirs)
+	})
+
+	t.Run("should ignore files that are not go.mod and de-duplicate repeats", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		paths := []string{"go.sum", "tools/go.mod", "./tools/go.mod", "README.md"}
+
+		// when
+		dirs := goUpdater.ModuleDirsFromPaths(paths)
+
+		// then
+		assert.Equal(t, []string{"tools"}, dirs)
+	})
+
+	t.Run("should return no directories when the repository has no module", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		paths := []string{"main.tf", "README.md"}
+
+		// when
+		dirs := goUpdater.ModuleDirsFromPaths(paths)
+
+		// then
+		assert.Empty(t, dirs)
+	})
+}
+
+func TestDiscoverLocalModuleDirs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should find the root module and every nested module", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repoDir := t.TempDir()
+		writeModule(t, repoDir, ".", "1.24.0")
+		writeModule(t, repoDir, "tests/harness", "1.23.1")
+
+		// when
+		dirs := goUpdater.DiscoverLocalModuleDirs(repoDir)
+
+		// then
+		assert.Equal(t, []string{".", "tests/harness"}, dirs)
+	})
+
+	t.Run("should find a nested module when the repository has no root module", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repoDir := t.TempDir()
+		writeModule(t, repoDir, "tests/harness", "1.23.1")
+
+		// when
+		dirs := goUpdater.DiscoverLocalModuleDirs(repoDir)
+
+		// then
+		assert.Equal(t, []string{"tests/harness"}, dirs)
+	})
+
+	t.Run("should skip vendored modules", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repoDir := t.TempDir()
+		writeModule(t, repoDir, ".", "1.24.0")
+		writeModule(t, repoDir, "vendor/example.com/dep", "1.19")
+
+		// when
+		dirs := goUpdater.DiscoverLocalModuleDirs(repoDir)
+
+		// then
+		assert.Equal(t, []string{"."}, dirs)
+	})
+
+	t.Run("should return no directories when the repository holds no Go module", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repoDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(repoDir, "main.tf"), []byte("# tf\n"), 0o600))
+
+		// when
+		dirs := goUpdater.DiscoverLocalModuleDirs(repoDir)
+
+		// then
+		assert.Empty(t, dirs)
+	})
+}
+
+func TestDiscoverRemoteModuleDirs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return module directories from the provider listing", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithFiles([]entities.File{
+				{Path: "tests/harness/go.mod"},
+				{Path: "go.mod"},
+			}).
+			BuildSpy()
+		repo := entities.Repository{Organization: "org", Name: "repo"}
+
+		// when
+		dirs := goUpdater.DiscoverRemoteModuleDirs(t.Context(), provider, repo)
+
+		// then
+		assert.Equal(t, []string{".", "tests/harness"}, dirs)
+	})
+
+	t.Run("should ignore directory entries returned by the provider", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithFiles([]entities.File{
+				{Path: "tools", IsDir: true},
+				{Path: "tools/go.mod"},
+			}).
+			BuildSpy()
+		repo := entities.Repository{Organization: "org", Name: "repo"}
+
+		// when
+		dirs := goUpdater.DiscoverRemoteModuleDirs(t.Context(), provider, repo)
+
+		// then
+		assert.Equal(t, []string{"tools"}, dirs)
+	})
+
+	t.Run("should return no directories when listing fails", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithListFileErr(errors.New("listing failed")).
+			BuildSpy()
+		repo := entities.Repository{Organization: "org", Name: "repo"}
+
+		// when
+		dirs := goUpdater.DiscoverRemoteModuleDirs(t.Context(), provider, repo)
+
+		// then
+		assert.Empty(t, dirs)
+	})
+}
+
+func TestGoModPathFor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return the bare manifest name for the root module", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		dir := "."
+
+		// when
+		path := goUpdater.GoModPathFor(dir)
+
+		// then
+		assert.Equal(t, "go.mod", path)
+	})
+
+	t.Run("should join the manifest name onto a nested module directory", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		dir := "tests/harness"
+
+		// when
+		path := goUpdater.GoModPathFor(dir)
+
+		// then
+		assert.Equal(t, "tests/harness/go.mod", path)
+	})
+}
+
+// runUpgradeScript renders the Go upgrade commands and executes them against
+// repoDir with a stubbed `go` binary, so the loop over modules is exercised
+// for real without touching the network or the Go toolchain.
+func runUpgradeScript(t *testing.T, repoDir, goVersion string) string {
+	t.Helper()
+
+	bashPath, lookErr := exec.LookPath("bash")
+	if lookErr != nil {
+		t.Skip("bash is not available on this platform")
+	}
+
+	var sb strings.Builder
+	sb.WriteString("#!/bin/bash\nset -euo pipefail\n\n")
+	goUpdater.WriteGoUpgradeCommands(&sb)
+	sb.WriteString("echo \"AGGREGATED_CHANGE=$GO_VERSION_CHANGED\"\n")
+
+	scriptDir := t.TempDir()
+	scriptPath := filepath.Join(scriptDir, "upgrade.sh")
+	require.NoError(t, os.WriteFile(scriptPath, []byte(sb.String()), 0o700)) //nolint:gosec // test script must execute
+
+	// A stub stands in for the real toolchain: the loop's job is to run the
+	// commands in each module directory, not to resolve dependencies.
+	stubPath := filepath.Join(scriptDir, "go-stub")
+	require.NoError(t, os.WriteFile(stubPath, []byte("#!/bin/bash\necho \"stub $* in $(pwd)\"\n"), 0o700)) //nolint:gosec // test stub must execute
+
+	cmd := exec.CommandContext(t.Context(), bashPath, scriptPath)
+	cmd.Dir = repoDir
+	cmd.Env = append(os.Environ(), "GO_VERSION="+goVersion, "GO_BINARY="+stubPath)
+
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "upgrade script failed:\n%s", output)
+
+	return string(output)
+}
+
+// goDirectiveOf reads the go directive of the module at repoDir/relDir.
+func goDirectiveOf(t *testing.T, repoDir, relDir string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(repoDir, filepath.FromSlash(relDir), "go.mod"))
+	require.NoError(t, err)
+
+	return goUpdater.ParseGoDirective(string(data))
+}
+
+func TestWriteGoUpgradeCommands(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should upgrade the root module and every nested module", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repoDir := t.TempDir()
+		writeModule(t, repoDir, ".", "1.24.0")
+		writeModule(t, repoDir, "tests/harness", "1.23.1")
+
+		// when
+		output := runUpgradeScript(t, repoDir, "1.25.7")
+
+		// then
+		assert.Equal(t, "1.25.7", goDirectiveOf(t, repoDir, "."))
+		assert.Equal(t, "1.25.7", goDirectiveOf(t, repoDir, "tests/harness"))
+		assert.Contains(t, output, "GO_VERSION_UPDATED=true")
+		assert.Contains(t, output, "AGGREGATED_CHANGE=true")
+	})
+
+	t.Run("should upgrade a nested module when the repository has no root module", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repoDir := t.TempDir()
+		writeModule(t, repoDir, "tests/harness", "1.23.1")
+
+		// when
+		output := runUpgradeScript(t, repoDir, "1.25.7")
+
+		// then
+		assert.Equal(t, "1.25.7", goDirectiveOf(t, repoDir, "tests/harness"))
+		assert.Contains(t, output, "AGGREGATED_CHANGE=true")
+	})
+
+	t.Run("should run the toolchain inside each module directory", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repoDir := t.TempDir()
+		writeModule(t, repoDir, ".", "1.25.7")
+		writeModule(t, repoDir, "tools", "1.25.7")
+
+		// when
+		output := runUpgradeScript(t, repoDir, "1.25.7")
+
+		// then
+		assert.Contains(t, output, "stub mod tidy in "+filepath.Join(repoDir, "tools"))
+		assert.Contains(t, output, "AGGREGATED_CHANGE=false",
+			"no directive changes when every module already matches the target")
+	})
+
+	t.Run("should leave vendored modules untouched", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repoDir := t.TempDir()
+		writeModule(t, repoDir, ".", "1.24.0")
+		writeModule(t, repoDir, "vendor/example.com/dep", "1.19")
+
+		// when
+		runUpgradeScript(t, repoDir, "1.25.7")
+
+		// then
+		assert.Equal(t, "1.25.7", goDirectiveOf(t, repoDir, "."))
+		assert.Equal(t, "1.19", goDirectiveOf(t, repoDir, "vendor/example.com/dep"))
+	})
+
+	t.Run("should exit cleanly when the repository holds no Go module", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repoDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(repoDir, "main.tf"), []byte("# tf\n"), 0o600))
+
+		// when
+		output := runUpgradeScript(t, repoDir, "1.25.7")
+
+		// then
+		assert.Contains(t, output, "no go.mod found in the repository")
+		assert.Contains(t, output, "GO_VERSION_UPDATED=false")
+	})
+}
+
+func TestResolveCurrentGoDirective(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should read the root module without scanning for nested modules", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		scanned := false
+		read := func(_ string) (string, error) { return "module m\n\ngo 1.24.0\n", nil }
+		nested := func() []string {
+			scanned = true
+			return nil
+		}
+
+		// when
+		version, sourceDir, found := goUpdater.ResolveCurrentGoDirective(read, nested)
+
+		// then
+		require.True(t, found)
+		assert.Equal(t, "1.24.0", version)
+		assert.Equal(t, ".", sourceDir)
+		assert.False(t, scanned, "nested modules should not be scanned when a root module exists")
+	})
+
+	t.Run("should fall back to the first nested module when the root has no go.mod", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		read := func(dir string) (string, error) {
+			if dir == "tests/harness" {
+				return "module m\n\ngo 1.23.1\n", nil
+			}
+			return "", errors.New("not found")
+		}
+		nested := func() []string { return []string{"tests/harness"} }
+
+		// when
+		version, sourceDir, found := goUpdater.ResolveCurrentGoDirective(read, nested)
+
+		// then
+		require.True(t, found)
+		assert.Equal(t, "1.23.1", version)
+		assert.Equal(t, "tests/harness", sourceDir)
+	})
+
+	t.Run("should report not found when no module can be read", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		read := func(_ string) (string, error) { return "", errors.New("not found") }
+		nested := func() []string { return []string{"tests/harness"} }
+
+		// when
+		_, _, found := goUpdater.ResolveCurrentGoDirective(read, nested)
+
+		// then
+		assert.False(t, found)
+	})
+}

--- a/internal/infrastructure/repositories/golang/modules_test.go
+++ b/internal/infrastructure/repositories/golang/modules_test.go
@@ -23,6 +23,9 @@ func writeModule(t *testing.T, repoDir, relDir, goVersion string) {
 	t.Helper()
 
 	dir := filepath.Join(repoDir, filepath.FromSlash(relDir))
+	// A directory needs the owner execute (search) bit, so 0o700 (not the rule's
+	// 0o600 file threshold) is the least-privilege mode; owner-only is sufficient.
+	// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
 	require.NoError(t, os.MkdirAll(dir, 0o700))
 	require.NoError(t, os.WriteFile(
 		filepath.Join(dir, "go.mod"),
@@ -414,6 +417,9 @@ func TestWriteGoUpgradeCommands(t *testing.T) {
 
 		// given a module whose go.mod has no go directive, ordered before a stale one
 		repoDir := t.TempDir()
+		// A directory needs the owner execute (search) bit, so 0o700 (not the rule's
+		// 0o600 file threshold) is the least-privilege mode; owner-only is sufficient.
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
 		require.NoError(t, os.MkdirAll(filepath.Join(repoDir, "broken"), 0o700))
 		require.NoError(t, os.WriteFile(
 			filepath.Join(repoDir, "broken", "go.mod"), []byte("module example.com/broken\n"), 0o600))

--- a/internal/infrastructure/repositories/golang/modules_test.go
+++ b/internal/infrastructure/repositories/golang/modules_test.go
@@ -86,6 +86,19 @@ func TestModuleDirsFromPaths(t *testing.T) {
 		assert.Equal(t, []string{".", "-tools"}, dirs)
 	})
 
+	t.Run("should strip the leading slash of absolute provider item paths", func(t *testing.T) {
+		t.Parallel()
+
+		// given paths in the absolute form Azure DevOps returns
+		paths := []string{"/go.mod", "/tests/harness/go.mod", "/vendor/dep/go.mod"}
+
+		// when
+		dirs := goUpdater.ModuleDirsFromPaths(paths)
+
+		// then
+		assert.Equal(t, []string{".", "tests/harness"}, dirs)
+	})
+
 	t.Run("should skip vendored, fixture and hidden modules", func(t *testing.T) {
 		t.Parallel()
 
@@ -396,6 +409,39 @@ func TestWriteGoUpgradeCommands(t *testing.T) {
 		assert.Equal(t, "1.19", goDirectiveOf(t, repoDir, "vendor/example.com/dep"))
 	})
 
+	t.Run("should keep upgrading other modules when one declares no go directive", func(t *testing.T) {
+		t.Parallel()
+
+		// given a module whose go.mod has no go directive, ordered before a stale one
+		repoDir := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(repoDir, "broken"), 0o700))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(repoDir, "broken", "go.mod"), []byte("module example.com/broken\n"), 0o600))
+		writeModule(t, repoDir, "tools", "1.23.1")
+
+		// when
+		output := runUpgradeScript(t, repoDir, "1.25.7")
+
+		// then
+		assert.Contains(t, output, "no go directive found in go.mod")
+		assert.Equal(t, "1.25.7", goDirectiveOf(t, repoDir, "tools"),
+			"a module without a directive must not abort the modules after it")
+	})
+
+	t.Run("should upgrade a module directory whose name starts with a dash", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repoDir := t.TempDir()
+		writeModule(t, repoDir, "-tools", "1.23.1")
+
+		// when
+		runUpgradeScript(t, repoDir, "1.25.7")
+
+		// then
+		assert.Equal(t, "1.25.7", goDirectiveOf(t, repoDir, "-tools"))
+	})
+
 	t.Run("should exit cleanly when the repository holds no Go module", func(t *testing.T) {
 		t.Parallel()
 
@@ -412,48 +458,105 @@ func TestWriteGoUpgradeCommands(t *testing.T) {
 	})
 }
 
-func TestResolveCurrentGoDirective(t *testing.T) {
+// moduleReader returns a reader over a directory-to-go-directive map.
+func moduleReader(modules map[string]string) func(string) (string, error) {
+	return func(dir string) (string, error) {
+		version, ok := modules[dir]
+		if !ok {
+			return "", errors.New("no such module")
+		}
+		return "module example.com/m\n\ngo " + version + "\n", nil
+	}
+}
+
+func TestWriteCommitAndPush(t *testing.T) {
 	t.Parallel()
 
-	t.Run("should read the root module without scanning for nested modules", func(t *testing.T) {
+	t.Run("should keep the Go version in the commit subject", func(t *testing.T) {
+		t.Parallel()
+
+		// given the version-bump commit subject wraps the version in backticks,
+		// which bash treats as command substitution unless they are escaped
+		var sb strings.Builder
+		goUpdater.WriteCommitAndPush(&sb)
+
+		// when
+		script := sb.String()
+
+		// then
+		assert.Contains(t, script, "\\`$GO_VERSION\\`")
+		assert.NotContains(t, script, "to `$GO_VERSION`")
+	})
+}
+
+func TestResolveVersionUpgradeNeed(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should short-circuit on a stale root without scanning for modules", func(t *testing.T) {
 		t.Parallel()
 
 		// given
 		scanned := false
-		read := func(_ string) (string, error) { return "module m\n\ngo 1.24.0\n", nil }
-		nested := func() []string {
+		read := moduleReader(map[string]string{".": "1.24.0"})
+		dirs := func() []string {
 			scanned = true
 			return nil
 		}
 
 		// when
-		version, sourceDir, found := goUpdater.ResolveCurrentGoDirective(read, nested)
+		needed, sourceDir, found := goUpdater.ResolveVersionUpgradeNeed(read, dirs, "1.25.7")
 
 		// then
 		require.True(t, found)
-		assert.Equal(t, "1.24.0", version)
+		assert.True(t, needed)
 		assert.Equal(t, ".", sourceDir)
-		assert.False(t, scanned, "nested modules should not be scanned when a root module exists")
+		assert.False(t, scanned, "a stale root already settles the decision")
 	})
 
-	t.Run("should fall back to the first nested module when the root has no go.mod", func(t *testing.T) {
+	t.Run("should require an upgrade when only a nested module is behind", func(t *testing.T) {
+		t.Parallel()
+
+		// given the root is already current but a nested module is not
+		read := moduleReader(map[string]string{".": "1.25.7", "tools": "1.23.1"})
+		dirs := func() []string { return []string{".", "tools"} }
+
+		// when
+		needed, sourceDir, found := goUpdater.ResolveVersionUpgradeNeed(read, dirs, "1.25.7")
+
+		// then
+		require.True(t, found)
+		assert.True(t, needed, "the script bumps every module, so the decision must span them all")
+		assert.Equal(t, "tools", sourceDir)
+	})
+
+	t.Run("should not require an upgrade when every module is current", func(t *testing.T) {
 		t.Parallel()
 
 		// given
-		read := func(dir string) (string, error) {
-			if dir == "tests/harness" {
-				return "module m\n\ngo 1.23.1\n", nil
-			}
-			return "", errors.New("not found")
-		}
-		nested := func() []string { return []string{"tests/harness"} }
+		read := moduleReader(map[string]string{".": "1.25.7", "tools": "1.25.7"})
+		dirs := func() []string { return []string{".", "tools"} }
 
 		// when
-		version, sourceDir, found := goUpdater.ResolveCurrentGoDirective(read, nested)
+		needed, _, found := goUpdater.ResolveVersionUpgradeNeed(read, dirs, "1.25.7")
 
 		// then
 		require.True(t, found)
-		assert.Equal(t, "1.23.1", version)
+		assert.False(t, needed)
+	})
+
+	t.Run("should decide from a nested module when the root has no go.mod", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		read := moduleReader(map[string]string{"tests/harness": "1.23.1"})
+		dirs := func() []string { return []string{"tests/harness"} }
+
+		// when
+		needed, sourceDir, found := goUpdater.ResolveVersionUpgradeNeed(read, dirs, "1.25.7")
+
+		// then
+		require.True(t, found)
+		assert.True(t, needed)
 		assert.Equal(t, "tests/harness", sourceDir)
 	})
 
@@ -461,11 +564,11 @@ func TestResolveCurrentGoDirective(t *testing.T) {
 		t.Parallel()
 
 		// given
-		read := func(_ string) (string, error) { return "", errors.New("not found") }
-		nested := func() []string { return []string{"tests/harness"} }
+		read := moduleReader(map[string]string{})
+		dirs := func() []string { return []string{"tests/harness"} }
 
 		// when
-		_, _, found := goUpdater.ResolveCurrentGoDirective(read, nested)
+		_, _, found := goUpdater.ResolveVersionUpgradeNeed(read, dirs, "1.25.7")
 
 		// then
 		assert.False(t, found)


### PR DESCRIPTION
## Summary

The Go updater only ever looked at the `go.mod` in the repository root. That had two consequences:

1. **Repositories with a nested module were never processed at all.** `Detect()` asks the provider whether a root `go.mod` exists, so a repository that keeps its Go module in a subdirectory — for example an infrastructure repository whose integration-test harness is its own module — answered "no" and was skipped by the Go updater entirely.
2. **Nested modules were never upgraded.** The upgrade script runs `go get -u -t ./...` and `go mod tidy` from the repository root, and neither command crosses a module boundary. So even when a root module did exist, any sibling module stayed permanently outdated.

This PR makes the updater module-aware.

## Changes

- **Discovery** — a new `modules.go` finds every `go.mod` in a repository, both on disk (via `support.WalkFilesByPredicate`) and through the provider API (via `ListFiles`), mirroring the dual-mode split the Terraform updater already uses. Vendored, `testdata`, `node_modules` and hidden directories are excluded so their pinned manifests are never rewritten.
- **Detection** — `Detect()` falls back to the full `go.mod` listing when the root declares no module.
- **Upgrade** — the generated bash now loops over each discovered module directory, applying the `go` directive bump, `go get -u -t ./...`, `go mod tidy` and a per-module `go mod vendor` in each. The module list is fed through a heredoc rather than a pipe, so the loop body runs in the current shell and the aggregate "version changed" flag survives it.
- **Version context** — branch naming and changelog wording fall back to the first nested module when the root declares no module. The root is still consulted first, so single-module repositories still cost exactly one lookup.

## Testing

- `make lint` — 0 issues
- `make test` — all 15 packages pass
- `make sast` — Semgrep 0 findings, Gitleaks no leaks

The new tests execute the **generated bash for real** against temporary fixtures with a stubbed `go` binary, covering: root and nested modules both upgraded, nested-only repositories, the toolchain running inside each module's own directory, vendored modules left untouched, module directories containing spaces, and a clean exit when the repository holds no module.

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?
- [x] Did you run all the code checks? (`go test`)
- [x] Are the tests passing?

## Follow-up: defects found in adversarial review

A review pass over the first commit found real defects, since fixed in `31f3932` — each now has a regression test that was confirmed to fail without its fix:

- **The upgrade decision was made from the root module alone.** With a current root and a stale nested module, the run was labelled "dependencies only" while the script bumped the nested `go` directive — producing a PR whose title said "upgraded Go version" while the changelog entry said dependencies only, on a `chore/upgrade-go-deps` branch. This is the feature's headline scenario, so it mattered. The decision now spans every module; a stale root still short-circuits, so single-module repositories keep costing one lookup.
- **A `go.mod` with no `go` directive aborted the whole run.** `grep` exits non-zero on no match, and under `set -o pipefail` that killed the script, leaving modules already processed in that run half-upgraded — and it made the existing "no directive" branch dead code.
- **The Go version was silently dropped from the commit subject.** The backticks around `$GO_VERSION` were unescaped, so bash expanded them as command substitution and committed `upgraded Go version to  and updated all dependencies`. Pre-existing, but it is the commit path this feature feeds.
- **A module directory named with a leading `-` broke `pushd`**, which parsed it as a stack-index option.
- **Azure DevOps returns absolute item paths** (`/go.mod`), so the repository root was recorded as `/` and never recognised as the root.
- **A single unreadable subdirectory discarded every locally discovered module**; partial scan results are now kept, matching what the upgrade script already did.
