### PR TITLE
chore(fixtures): replaced the sample organization name with a neutral placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- replaced the sample organization name used across the test fixtures, `README.md` and the `exclusion.go` doc comments with a neutral `ContosoSecurity` placeholder, so the examples no longer reference a real private Azure DevOps organization
+
 ### Fixed
 
 - fixed the Go updater writing non-existent Docker base image tags into `Dockerfile` `FROM` clauses: it now verifies each target `golang:<version>` tag is published on Docker Hub before rewriting, falls back to the closest published patch within the same minor and suffix, and leaves the clause untouched when no suitable image exists — instead of blindly applying the latest `go.dev` version via `sed`, which could point `FROM` at an unpublished patch (registry lag) or a dropped Alpine variant such as `golang:1.25.7-alpine3.20`

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ concurrency: 4
 # Glob wildcards (*, ?, [...]) follow path.Match semantics and do not
 # cross "/". A bare name matches the repo's trailing segment.
 exclude_repos:
-  - 'ZestSecurity/frontend/opensearch-dashboards'  # exact ADO path
+  - 'ContosoSecurity/frontend/opensearch-dashboards'  # exact ADO path
   - '*/oui'                                         # any org or org/project ending in /oui
   - 'rios0rios0/private-fork'                       # exact GitHub path
 

--- a/internal/domain/commands/local_command_test.go
+++ b/internal/domain/commands/local_command_test.go
@@ -564,7 +564,7 @@ func TestIsExcludedByGlobalList(t *testing.T) {
 	t.Parallel()
 
 	github := &commands.RemoteInfo{Org: "rios0rios0", RepoName: "autoupdate"}
-	ado := &commands.RemoteInfo{Org: "ZestSecurity", Project: "frontend", RepoName: "opensearch-dashboards"}
+	ado := &commands.RemoteInfo{Org: "ContosoSecurity", Project: "frontend", RepoName: "opensearch-dashboards"}
 
 	t.Run("should return false when settings is nil", func(t *testing.T) {
 		t.Parallel()
@@ -607,7 +607,7 @@ func TestIsExcludedByGlobalList(t *testing.T) {
 
 		// given
 		settings := &entities.Settings{ExcludeRepos: []string{
-			"ZestSecurity/frontend/opensearch-dashboards",
+			"ContosoSecurity/frontend/opensearch-dashboards",
 		}}
 
 		// when

--- a/internal/domain/commands/run_command_test.go
+++ b/internal/domain/commands/run_command_test.go
@@ -1615,12 +1615,12 @@ func TestFilterRepositories(t *testing.T) {
 
 		// given
 		repos := []entities.Repository{
-			{Organization: "ZestSecurity", Project: "frontend", Name: "opensearch-dashboards"},
-			{Organization: "ZestSecurity", Project: "frontend", Name: "oui"},
-			{Organization: "ZestSecurity", Project: "frontend", Name: "regular"},
+			{Organization: "ContosoSecurity", Project: "frontend", Name: "opensearch-dashboards"},
+			{Organization: "ContosoSecurity", Project: "frontend", Name: "oui"},
+			{Organization: "ContosoSecurity", Project: "frontend", Name: "regular"},
 		}
 		settings := &entities.Settings{ExcludeRepos: []string{
-			"ZestSecurity/frontend/opensearch-dashboards",
+			"ContosoSecurity/frontend/opensearch-dashboards",
 			"*/oui",
 		}}
 
@@ -1643,7 +1643,7 @@ func TestRunCommandRunsExcludeRepos(t *testing.T) {
 		excluded := entitybuilders.NewRepositoryBuilder().
 			WithID("excl").
 			WithName("opensearch-dashboards").
-			WithOrganization("ZestSecurity").
+			WithOrganization("ContosoSecurity").
 			WithDefaultBranch("refs/heads/main").
 			BuildRepository()
 		excluded.Project = "frontend"
@@ -1651,7 +1651,7 @@ func TestRunCommandRunsExcludeRepos(t *testing.T) {
 		kept := entitybuilders.NewRepositoryBuilder().
 			WithID("kept").
 			WithName("regular").
-			WithOrganization("ZestSecurity").
+			WithOrganization("ContosoSecurity").
 			WithDefaultBranch("refs/heads/main").
 			BuildRepository()
 
@@ -1682,10 +1682,10 @@ func TestRunCommandRunsExcludeRepos(t *testing.T) {
 				entitybuilders.NewProviderConfigBuilder().
 					WithType("azuredevops").
 					WithToken("ado-token").
-					WithOrganizations([]string{"ZestSecurity"}).
+					WithOrganizations([]string{"ContosoSecurity"}).
 					BuildProviderConfig(),
 			}).
-			WithExcludeRepos([]string{"ZestSecurity/frontend/opensearch-dashboards"}).
+			WithExcludeRepos([]string{"ContosoSecurity/frontend/opensearch-dashboards"}).
 			BuildSettings()
 
 		// when
@@ -1708,7 +1708,7 @@ func TestRunCommandRunsRepoConfigSkip(t *testing.T) {
 		repo := entitybuilders.NewRepositoryBuilder().
 			WithID("opted-out").
 			WithName("opensearch-dashboards").
-			WithOrganization("ZestSecurity").
+			WithOrganization("ContosoSecurity").
 			WithDefaultBranch("refs/heads/main").
 			BuildRepository()
 
@@ -1742,7 +1742,7 @@ func TestRunCommandRunsRepoConfigSkip(t *testing.T) {
 				entitybuilders.NewProviderConfigBuilder().
 					WithType("github").
 					WithToken("test-token").
-					WithOrganizations([]string{"ZestSecurity"}).
+					WithOrganizations([]string{"ContosoSecurity"}).
 					BuildProviderConfig(),
 			}).
 			BuildSettings()

--- a/internal/domain/entities/exclusion.go
+++ b/internal/domain/entities/exclusion.go
@@ -30,7 +30,7 @@ func RepoKey(repo Repository) string {
 //     regardless of org/project prefix.
 //   - `*/oui` matches `<anything>/oui`, including the trailing two
 //     segments of an Azure DevOps `org/project/oui` key.
-//   - `zestsecurity/frontend/opensearch-dashboards` only matches that
+//   - `contososecurity/frontend/opensearch-dashboards` only matches that
 //     exact ADO path.
 //
 // `*` follows `path.Match` semantics (it does not cross `/`). The first

--- a/internal/domain/entities/exclusion_test.go
+++ b/internal/domain/entities/exclusion_test.go
@@ -31,7 +31,7 @@ func TestRepoKey(t *testing.T) {
 
 		// given
 		repo := entities.Repository{
-			Organization: "ZestSecurity",
+			Organization: "ContosoSecurity",
 			Project:      "frontend",
 			Name:         "opensearch-dashboards",
 		}
@@ -40,7 +40,7 @@ func TestRepoKey(t *testing.T) {
 		key := entities.RepoKey(repo)
 
 		// then
-		assert.Equal(t, "zestsecurity/frontend/opensearch-dashboards", key)
+		assert.Equal(t, "contososecurity/frontend/opensearch-dashboards", key)
 	})
 
 	t.Run("should lowercase every segment for case-insensitive matching", func(t *testing.T) {
@@ -62,7 +62,7 @@ func TestMatchesExcludePattern(t *testing.T) {
 
 	githubRepo := entities.Repository{Organization: "rios0rios0", Name: "autoupdate"}
 	adoRepo := entities.Repository{
-		Organization: "ZestSecurity",
+		Organization: "ContosoSecurity",
 		Project:      "frontend",
 		Name:         "opensearch-dashboards",
 	}
@@ -99,14 +99,14 @@ func TestMatchesExcludePattern(t *testing.T) {
 		t.Parallel()
 
 		// given
-		patterns := []string{"ZestSecurity/frontend/opensearch-dashboards"}
+		patterns := []string{"ContosoSecurity/frontend/opensearch-dashboards"}
 
 		// when
 		matched, pattern := entities.MatchesExcludePattern(adoRepo, patterns)
 
 		// then
 		assert.True(t, matched)
-		assert.Equal(t, "ZestSecurity/frontend/opensearch-dashboards", pattern)
+		assert.Equal(t, "ContosoSecurity/frontend/opensearch-dashboards", pattern)
 	})
 
 	t.Run("should support glob wildcards on the org segment", func(t *testing.T) {
@@ -114,7 +114,7 @@ func TestMatchesExcludePattern(t *testing.T) {
 
 		// given
 		patterns := []string{"*/oui"}
-		repo := entities.Repository{Organization: "ZestSecurity", Name: "oui"}
+		repo := entities.Repository{Organization: "ContosoSecurity", Name: "oui"}
 
 		// when
 		matched, pattern := entities.MatchesExcludePattern(repo, patterns)
@@ -128,14 +128,14 @@ func TestMatchesExcludePattern(t *testing.T) {
 		t.Parallel()
 
 		// given
-		patterns := []string{"zestsecurity/frontend/*"}
+		patterns := []string{"contososecurity/frontend/*"}
 
 		// when
 		matched, pattern := entities.MatchesExcludePattern(adoRepo, patterns)
 
 		// then
 		assert.True(t, matched)
-		assert.Equal(t, "zestsecurity/frontend/*", pattern)
+		assert.Equal(t, "contososecurity/frontend/*", pattern)
 	})
 
 	t.Run("should match a bare repo name against the trailing segment", func(t *testing.T) {

--- a/internal/domain/entities/settings_test.go
+++ b/internal/domain/entities/settings_test.go
@@ -318,7 +318,7 @@ func TestValidateSettings(t *testing.T) {
 			ExcludeRepos: []string{
 				"rios0rios0/autoupdate",
 				"*/oui",
-				"zestsecurity/frontend/*",
+				"contososecurity/frontend/*",
 				"opensearch-dashboards",
 			},
 		}


### PR DESCRIPTION
Test fixtures, `README.md` and the `exclusion.go` doc comments used a real private Azure DevOps organization name as their example. Replaced it with a neutral `ContosoSecurity` placeholder across 6 files.

`go.sum` is deliberately **not** touched: one module digest contains the old string as an incidental base64 substring, and rewriting it would corrupt the checksum and break the build.

Behaviour is unchanged — the name is only ever sample data. `make test` passes.

> Scope note: this cleans the working tree only. The name remains in this repository's git history (6 commits); that is tracked as separate follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)