### PR TITLE
fix(gitleaks): re-pointed the allowlist fingerprints at the rebased commits

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -32,26 +32,37 @@ internal/infrastructure/repositories/csharp/csharp_updater_repository.go:Passwor
 internal/infrastructure/repositories/csharp/csharp_updater_repository.go:Password in URL:596
 internal/infrastructure/repositories/csharp/csharp_updater_repository.go:Password in URL:600
 
+# Entries below are full fingerprints: <commit>:<file>:<rule-id>:<line>. Because the
+# fingerprint embeds the commit, a rewritten history invalidates every entry: a rebase
+# gives the offending commit a new hash, the old fingerprint stops matching anything,
+# and the finding comes back. Re-point the entries at the new hash rather than adding a
+# second set -- the orphaned commit is unreachable from HEAD, so the scan never walks it
+# again.
+#
 # 2026-06-09: historical false positives from gitleaks pass 2 (the GitLab-customised ruleset
 # scanning full history). All 14 are the "Password in URL" rule matching git-remote
 # authentication URLs that the code assembles at runtime from variables (an auth-token
 # environment variable and Go string concatenation) plus placeholder tokens in test
 # fixtures -- none are real secrets. The same code is already suppressed above at its
-# current-tree paths; these fingerprints cover the pre-refactor paths in commits 66f4a905
-# (2026-02-07) and 0839817b (2026-02-12) so the unchanged history stops failing the
-# main-branch pipeline. (Comment kept free of literal credential URLs so it does not itself
-# trip the scanner.)
-0839817b71019c9bd820d27a2bfa2dd2a96bf0bb:infrastructure/updater/javascript/local.go:Password in URL:272
-0839817b71019c9bd820d27a2bfa2dd2a96bf0bb:infrastructure/updater/javascript/local.go:Password in URL:276
-0839817b71019c9bd820d27a2bfa2dd2a96bf0bb:infrastructure/updater/python/local.go:Password in URL:257
-0839817b71019c9bd820d27a2bfa2dd2a96bf0bb:infrastructure/updater/python/local.go:Password in URL:261
-0839817b71019c9bd820d27a2bfa2dd2a96bf0bb:infrastructure/updater/javascript/javascript.go:Password in URL:519
-0839817b71019c9bd820d27a2bfa2dd2a96bf0bb:infrastructure/updater/javascript/javascript.go:Password in URL:523
-0839817b71019c9bd820d27a2bfa2dd2a96bf0bb:infrastructure/updater/python/python.go:Password in URL:487
-0839817b71019c9bd820d27a2bfa2dd2a96bf0bb:infrastructure/updater/python/python.go:Password in URL:491
-66f4a905e8d7fdff1c0c91da2429dfcd6d8b2340:infrastructure/provider/github/github.go:Password in URL:366
-66f4a905e8d7fdff1c0c91da2429dfcd6d8b2340:infrastructure/provider/github/github_test.go:Password in URL:124
-66f4a905e8d7fdff1c0c91da2429dfcd6d8b2340:infrastructure/updater/golang/golang.go:Password in URL:318
-66f4a905e8d7fdff1c0c91da2429dfcd6d8b2340:infrastructure/updater/golang/golang.go:Password in URL:323
-66f4a905e8d7fdff1c0c91da2429dfcd6d8b2340:infrastructure/provider/gitlab/gitlab_test.go:Password in URL:114
-66f4a905e8d7fdff1c0c91da2429dfcd6d8b2340:infrastructure/provider/gitlab/gitlab.go:Password in URL:386
+# current-tree paths; these fingerprints cover the boilerplate (2026-02-07) and the
+# Python/JavaScript updater (2026-02-12) commits so the unchanged history stops failing
+# the main-branch pipeline. (Comment kept free of literal credential URLs so it does not
+# itself trip the scanner.)
+#
+# 2026-07-23: re-pointed both commits after a rebase moved them -- 66f4a905 -> 801c483b
+# and 0839817b -> ce117d33. Same changes, same content, new hashes; the old ones are now
+# unreachable from HEAD. Nothing about the findings themselves changed.
+ce117d33ced5a786ac2d4da6cd1a482b9c529832:infrastructure/updater/javascript/local.go:Password in URL:272
+ce117d33ced5a786ac2d4da6cd1a482b9c529832:infrastructure/updater/javascript/local.go:Password in URL:276
+ce117d33ced5a786ac2d4da6cd1a482b9c529832:infrastructure/updater/python/local.go:Password in URL:257
+ce117d33ced5a786ac2d4da6cd1a482b9c529832:infrastructure/updater/python/local.go:Password in URL:261
+ce117d33ced5a786ac2d4da6cd1a482b9c529832:infrastructure/updater/javascript/javascript.go:Password in URL:519
+ce117d33ced5a786ac2d4da6cd1a482b9c529832:infrastructure/updater/javascript/javascript.go:Password in URL:523
+ce117d33ced5a786ac2d4da6cd1a482b9c529832:infrastructure/updater/python/python.go:Password in URL:487
+ce117d33ced5a786ac2d4da6cd1a482b9c529832:infrastructure/updater/python/python.go:Password in URL:491
+801c483bbd25a33e85f66d32e98dbea0724c4934:infrastructure/provider/github/github.go:Password in URL:366
+801c483bbd25a33e85f66d32e98dbea0724c4934:infrastructure/provider/github/github_test.go:Password in URL:124
+801c483bbd25a33e85f66d32e98dbea0724c4934:infrastructure/updater/golang/golang.go:Password in URL:318
+801c483bbd25a33e85f66d32e98dbea0724c4934:infrastructure/updater/golang/golang.go:Password in URL:323
+801c483bbd25a33e85f66d32e98dbea0724c4934:infrastructure/provider/gitlab/gitlab_test.go:Password in URL:114
+801c483bbd25a33e85f66d32e98dbea0724c4934:infrastructure/provider/gitlab/gitlab.go:Password in URL:386

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - changed cleanup to run only after the same-day pull request check has passed, so a pull request is
   never closed without a replacement being opened for it
 
+### Fixed
+
+- fixed the Gitleaks stage failing every build on `main`. The allowlisted fingerprints in
+  `.gitleaksignore` embed the hash of the commit a finding came from, so when a rebase moved the two
+  commits holding the historical git-remote URL false positives, all 14 entries stopped matching and
+  the long-suppressed findings came back. Re-pointed every entry at the commits' current hashes
+
 ## [0.17.0] - 2026-07-22
 
 ### Added


### PR DESCRIPTION
## Problem

`sast:gitleaks` is the only failing job on `main`, and has been for the last 3 builds (since #211). It passes pass 1 and fails pass 2 with `leaks found: 14` — all of them the `Password in URL` rule, spread over 8 files.

Every one was already triaged and allowlisted in `.gitleaksignore` back in June.

## Root cause

Nothing about the findings changed — **the two commits they live in were rebased**, so their hashes moved:

```
allowlisted: 66f4a905e8d7fdff1c0c91da2429dfcd6d8b2340 -> reported: 801c483bbd25a33e85f66d32e98dbea0724c4934  (6 findings)
allowlisted: 0839817b71019c9bd820d27a2bfa2dd2a96bf0bb -> reported: ce117d33ced5a786ac2d4da6cd1a482b9c529832  (8 findings)
```

Same changes, same content, same dates ("feat(boilerplate)…" 2026-02-07 and "feat(langs): added Python and JavaScript updater" 2026-02-12); the old hashes are now unreachable from `HEAD`.

A `.gitleaksignore` entry is a full fingerprint — `<commit>:<file>:<rule-id>:<line>` — so it embeds the commit hash. When a rebase rewrites that commit, all 14 entries stop matching, silently, and the findings resurface. Since branch builds scan `--log-opts HEAD` (all history), it fails every build from then on.

## Fix

Re-pointed all 14 entries at the commits' current hashes, and added a comment explaining this failure mode so the next occurrence is diagnosable.

No suppression was added or broadened — same files, same lines, same rule. The findings remain false positives on re-inspection: git-remote URLs assembled at runtime from a shell variable (`${AUTH_TOKEN}`) or Go string concatenation (`"+p.token+"`), plus obviously-fake fixture tokens (`ghp_secret123`, `glpat-secret`). No credential is committed.

## Verification

⚠️ **CI on this PR does not prove the fix.** The run script scopes PR builds to `origin/main..HEAD`, so findings from February history are out of scope and the job goes green regardless. Verified locally instead, reproducing exactly what a branch build does (`--log-opts HEAD`, both passes):

| | before | after |
|---|---|---|
| pass 1 (default ruleset) | `no leaks found` | `no leaks found` |
| pass 2 (GitLab ruleset) | `leaks found: 14` | `no leaks found` |

Fingerprints were re-derived from a fresh scan of current `main` rather than copied from the CI artifact, so they match what the pipeline will actually compute.

## Note

The 33 plain `<file>:<rule>:<line>` lines at the top of `.gitleaksignore` are left untouched by this PR, but they are inert: gitleaks only honours full fingerprints, and those paths (`internal/infrastructure/repositories/…`) no longer exist in the tree. Worth deleting in a follow-up — they read as active suppressions but suppress nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)