### PR TITLE
feat(python): detected PDM projects and upgraded them with PDM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,30 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added automatic PDM detection to the Python updater: a repository carrying a `pdm.lock`, a
+  `[tool.pdm]` table or the `pdm.backend` build backend is now upgraded with
+  `pdm update --update-all --no-sync` instead of raw pip. PDM resolves against its own lock file,
+  which pip cannot see, so a PDM project previously had its lock left untouched no matter how often
+  the updater ran. `--no-sync` keeps the run to a resolution, because the refreshed `pdm.lock` is the
+  only artefact worth committing
+
+### Changed
+
+- changed the Python pull request description and changelog entry to name the dependency manager the
+  run actually used. The description previously advertised `pip install --upgrade -r
+  requirements.txt` and asked reviewers to review `requirements.txt` even for projects that have no
+  such file
+
+### Fixed
+
+- fixed the Python updater committing the `*.egg-info/` directory as though it were a dependency
+  change. Installing a `pyproject.toml` project locally makes setuptools generate that directory;
+  because it was untracked but not ignored, `git add -A` swept it into the commit, so a repository
+  with no dependency movement at all still produced a pull request. The pattern is now added to
+  `.gitignore`, and only when such a directory actually exists, so repositories that never build the
+  project keep their `.gitignore` untouched
 ## [0.18.0] - 2026-07-27
 
 ### Added

--- a/internal/domain/commands/local_command.go
+++ b/internal/domain/commands/local_command.go
@@ -72,7 +72,7 @@ type localPRInfo struct {
 	BranchName     string
 	LatestVersion  string
 	VersionUpdated bool
-	PackageManager string // JavaScript only
+	PackageManager string // JavaScript package manager, or Python dependency manager
 	ProjectType    langEntities.Language
 	HasChanges     bool
 }
@@ -259,6 +259,7 @@ func runPythonLocalUpgrade(
 		BranchName:     result.BranchName,
 		LatestVersion:  result.LatestVersion,
 		VersionUpdated: result.PythonVersionUpdated,
+		PackageManager: result.Toolchain,
 		ProjectType:    langEntities.LanguagePython,
 		HasChanges:     result.HasChanges,
 	}, nil
@@ -351,7 +352,7 @@ func prContentGenerators() map[langEntities.Language]prContentGenerator {
 				)
 			}
 			desc := pyRepo.GeneratePRDescription(
-				info.LatestVersion, info.VersionUpdated,
+				info.LatestVersion, info.PackageManager, info.VersionUpdated,
 			)
 			return title, desc
 		},

--- a/internal/infrastructure/repositories/python/export_test.go
+++ b/internal/infrastructure/repositories/python/export_test.go
@@ -66,8 +66,37 @@ func BuildUpgradeScript(params UpgradeParamsExported, repoDir string) string {
 }
 
 // BuildBatchPythonScript is exported for testing.
-func BuildBatchPythonScript(hasRequirements, hasPyproject bool) string {
-	return buildBatchPythonScript(hasRequirements, hasPyproject)
+func BuildBatchPythonScript(hasRequirements, hasPyproject, hasPDM bool) string {
+	return buildBatchPythonScript(hasRequirements, hasPyproject, hasPDM)
+}
+
+// PyprojectUsesPDM is exported for testing.
+func PyprojectUsesPDM(content string) bool {
+	return pyprojectUsesPDM(content)
+}
+
+// HasPDMLocal is exported for testing.
+func HasPDMLocal(repoDir string) bool {
+	return hasPDMLocal(repoDir)
+}
+
+// HasPDMRemote is exported for testing.
+func HasPDMRemote(
+	ctx context.Context,
+	provider repositories.ProviderRepository,
+	repo entities.Repository,
+) bool {
+	return hasPDMRemote(ctx, provider, repo)
+}
+
+// ToolchainFor is exported for testing.
+func ToolchainFor(hasPDM bool) string {
+	return toolchainFor(hasPDM)
+}
+
+// WriteEggInfoGitignore is exported for testing.
+func WriteEggInfoGitignore(sb *strings.Builder) {
+	writeEggInfoGitignore(sb)
 }
 
 // WriteGitAuth is exported for testing.

--- a/internal/infrastructure/repositories/python/local.go
+++ b/internal/infrastructure/repositories/python/local.go
@@ -33,6 +33,7 @@ type LocalResult struct {
 	PythonVersionUpdated bool
 	LatestVersion        string
 	BranchName           string
+	Toolchain            string // dependency manager used: "pdm" or "pip"
 	Output               string
 }
 
@@ -113,6 +114,7 @@ func handleDryRun(vCtx *versionContext, repoDir string) *LocalResult {
 		LatestVersion:        vCtx.LatestVersion,
 		BranchName:           vCtx.BranchName,
 		PythonVersionUpdated: vCtx.NeedsVersionUpgrade,
+		Toolchain:            toolchainFor(hasPDMLocal(repoDir)),
 	}
 }
 
@@ -181,6 +183,7 @@ func executeLocalUpgrade(
 		PythonVersionUpdated: pythonVersionUpdated,
 		LatestVersion:        vCtx.LatestVersion,
 		BranchName:           vCtx.BranchName,
+		Toolchain:            toolchainFor(hasPDMLocal(repoDir)),
 		Output:               outputStr,
 	}, nil
 }
@@ -222,6 +225,7 @@ func runLanguageUpgradeScript(
 		ProviderName:    opts.ProviderName,
 		HasRequirements: hasRequirements,
 		HasPyproject:    hasPyproject,
+		HasPDM:          hasPyproject && hasPDMLocal(repoDir),
 		PythonBinary:    pythonBinary,
 	}
 
@@ -271,6 +275,7 @@ type localUpgradeParams struct {
 	ProviderName    string
 	HasRequirements bool
 	HasPyproject    bool
+	HasPDM          bool
 	PythonBinary    string
 }
 
@@ -292,7 +297,11 @@ func buildLocalUpgradeScript(params localUpgradeParams) string {
 	writePythonUpgradeCommands(&sb, upgradeParams{
 		HasRequirements: params.HasRequirements,
 		HasPyproject:    params.HasPyproject,
+		HasPDM:          params.HasPDM,
 	})
+
+	// Keep generated build metadata out of the commit
+	writeEggInfoGitignore(&sb)
 
 	// Update Dockerfile python image tags
 	writeDockerfileUpdate(&sb)

--- a/internal/infrastructure/repositories/python/python_updater_repository.go
+++ b/internal/infrastructure/repositories/python/python_updater_repository.go
@@ -381,13 +381,18 @@ type upgradeResult struct {
 // project. PDM keeps its own configuration under a [tool.pdm] table, and the
 // pdm-backend build backend is only ever declared by PDM projects, so either
 // marker identifies the project without needing a TOML parser.
+//
+// Comments are discarded before matching, so a marker named only in prose does
+// not select the PDM upgrade path. The table match is anchored to [tool.pdm]
+// and its sub-tables so an unrelated table such as [tool.pdmx] is not mistaken
+// for one of PDM's.
 func pyprojectUsesPDM(content string) bool {
 	for line := range strings.SplitSeq(content, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "#") {
+		trimmed := strings.TrimSpace(stripTOMLComment(line))
+		if trimmed == "" {
 			continue
 		}
-		if strings.HasPrefix(trimmed, "[tool.pdm") {
+		if trimmed == "[tool.pdm]" || strings.HasPrefix(trimmed, "[tool.pdm.") {
 			return true
 		}
 		if strings.Contains(trimmed, "pdm.backend") || strings.Contains(trimmed, "pdm-backend") {
@@ -395,6 +400,36 @@ func pyprojectUsesPDM(content string) bool {
 		}
 	}
 	return false
+}
+
+// stripTOMLComment removes an inline comment from a TOML line. A '#' carried
+// inside a quoted value is part of that value rather than the start of a
+// comment, so quoting is tracked while scanning; basic (double-quoted) strings
+// additionally honour backslash escapes, while literal (single-quoted) strings
+// have none. This is a best-effort scan, which is all the marker matching above
+// needs — it never has to interpret the values themselves.
+func stripTOMLComment(line string) string {
+	var quote rune
+	escaped := false
+
+	for i, r := range line {
+		switch {
+		case escaped:
+			escaped = false
+		case quote == '"' && r == '\\':
+			escaped = true
+		case quote != 0:
+			if r == quote {
+				quote = 0
+			}
+		case r == '\'' || r == '"':
+			quote = r
+		case r == '#':
+			return line[:i]
+		}
+	}
+
+	return line
 }
 
 // hasPDMRemote reports whether the remote repository is PDM-managed. A

--- a/internal/infrastructure/repositories/python/python_updater_repository.go
+++ b/internal/infrastructure/repositories/python/python_updater_repository.go
@@ -34,6 +34,12 @@ const (
 	// Commit/PR messages and changelog entries used across remote and local modes.
 	pyCommitMsgDeps      = "chore(deps): updated Python dependencies"
 	pyChangelogEntryDeps = "- changed the Python dependencies to their latest versions"
+
+	// Toolchain identifiers. A repository is upgraded either through PDM (when
+	// it is PDM-managed) or through plain pip, and the two produce different
+	// commands, changelog wording and PR descriptions.
+	toolchainPDM = "pdm"
+	toolchainPip = "pip"
 )
 
 // UpdaterRepository implements repositories.UpdaterRepository for Python dependencies.
@@ -153,6 +159,7 @@ func cloneAndUpgrade(
 	}
 	hasRequirements := provider.HasFile(ctx, repo, "requirements.txt")
 	hasPyproject := provider.HasFile(ctx, repo, "pyproject.toml")
+	hasPDM := hasPyproject && hasPDMRemote(ctx, provider, repo)
 
 	cloneURL := provider.CloneURL(repo)
 	defaultBranch := strings.TrimPrefix(repo.DefaultBranch, "refs/heads/")
@@ -172,11 +179,14 @@ func cloneAndUpgrade(
 		ChangelogFile:   changelogFile,
 		HasRequirements: hasRequirements,
 		HasPyproject:    hasPyproject,
+		HasPDM:          hasPDM,
 		PythonBinary:    pythonBinary,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to upgrade: %w", err)
 	}
+
+	result.Toolchain = toolchainFor(hasPDM)
 
 	return result, nil
 }
@@ -203,7 +213,7 @@ func openPullRequest(
 			vCtx.LatestVersion,
 		)
 	}
-	prDesc := GeneratePRDescription(vCtx.LatestVersion, result.PythonVersionUpdated)
+	prDesc := GeneratePRDescription(vCtx.LatestVersion, result.Toolchain, result.PythonVersionUpdated)
 
 	pr, createErr := provider.CreatePullRequest(ctx, repo, entities.PullRequestInput{
 		SourceBranch: "refs/heads/" + vCtx.BranchName,
@@ -248,12 +258,14 @@ func (u *UpdaterRepository) ApplyUpdates(
 		hasPyproject = true
 	}
 
+	hasPDM := hasPyproject && hasPDMLocal(repoDir)
+
 	pythonBinary, binErr := findPythonBinary()
 	if binErr != nil {
 		return nil, fmt.Errorf("python binary not found: %w", binErr)
 	}
 
-	script := buildBatchPythonScript(hasRequirements, hasPyproject)
+	script := buildBatchPythonScript(hasRequirements, hasPyproject, hasPDM)
 	scriptPath := filepath.Join(repoDir, ".autoupdate-upgrade.sh")
 	if writeErr := os.WriteFile(scriptPath, []byte(script), scriptFileMode); writeErr != nil {
 		return nil, fmt.Errorf("failed to write script: %w", writeErr)
@@ -291,8 +303,8 @@ func (u *UpdaterRepository) ApplyUpdates(
 	var entry string
 	if pyVersionUpdated {
 		entry = fmt.Sprintf(
-			"- changed the Python version to `%s` and updated all pip dependencies",
-			vCtx.LatestVersion,
+			"- changed the Python version to `%s` and updated all %s dependencies",
+			vCtx.LatestVersion, toolchainFor(hasPDM),
 		)
 	} else {
 		entry = pyChangelogEntryDeps
@@ -313,13 +325,13 @@ func (u *UpdaterRepository) ApplyUpdates(
 		BranchName:    vCtx.BranchName,
 		CommitMessage: commitMsg,
 		PRTitle:       prTitle,
-		PRDescription: GeneratePRDescription(vCtx.LatestVersion, pyVersionUpdated),
+		PRDescription: GeneratePRDescription(vCtx.LatestVersion, toolchainFor(hasPDM), pyVersionUpdated),
 	}, nil
 }
 
 // buildBatchPythonScript generates a bash script with only language-specific
 // operations (no git clone, branch, commit, or push) for the batch pipeline.
-func buildBatchPythonScript(hasRequirements, hasPyproject bool) string {
+func buildBatchPythonScript(hasRequirements, hasPyproject, hasPDM bool) string {
 	var sb strings.Builder
 
 	sb.WriteString("#!/bin/bash\n")
@@ -328,7 +340,9 @@ func buildBatchPythonScript(hasRequirements, hasPyproject bool) string {
 	writePythonUpgradeCommands(&sb, upgradeParams{
 		HasRequirements: hasRequirements,
 		HasPyproject:    hasPyproject,
+		HasPDM:          hasPDM,
 	})
+	writeEggInfoGitignore(&sb)
 	writeDockerfileUpdate(&sb)
 
 	return sb.String()
@@ -352,13 +366,76 @@ type upgradeParams struct {
 	ChangelogFile   string
 	HasRequirements bool
 	HasPyproject    bool
+	HasPDM          bool
 	PythonBinary    string
 }
 
 type upgradeResult struct {
 	HasChanges           bool
 	PythonVersionUpdated bool
+	Toolchain            string
 	Output               string
+}
+
+// pyprojectUsesPDM reports whether a pyproject.toml belongs to a PDM-managed
+// project. PDM keeps its own configuration under a [tool.pdm] table, and the
+// pdm-backend build backend is only ever declared by PDM projects, so either
+// marker identifies the project without needing a TOML parser.
+func pyprojectUsesPDM(content string) bool {
+	for line := range strings.SplitSeq(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "[tool.pdm") {
+			return true
+		}
+		if strings.Contains(trimmed, "pdm.backend") || strings.Contains(trimmed, "pdm-backend") {
+			return true
+		}
+	}
+	return false
+}
+
+// hasPDMRemote reports whether the remote repository is PDM-managed. A
+// pdm.lock is conclusive on its own; otherwise the pyproject.toml is inspected
+// for PDM's markers.
+func hasPDMRemote(
+	ctx context.Context,
+	provider repositories.ProviderRepository,
+	repo entities.Repository,
+) bool {
+	if provider.HasFile(ctx, repo, "pdm.lock") {
+		return true
+	}
+
+	content, err := provider.GetFileContent(ctx, repo, "pyproject.toml")
+	if err != nil {
+		return false
+	}
+	return pyprojectUsesPDM(content)
+}
+
+// hasPDMLocal reports whether a checked-out repository is PDM-managed, using
+// the same markers as [hasPDMRemote].
+func hasPDMLocal(repoDir string) bool {
+	if _, err := os.Stat(filepath.Join(repoDir, "pdm.lock")); err == nil {
+		return true
+	}
+
+	content, err := os.ReadFile(filepath.Clean(filepath.Join(repoDir, "pyproject.toml")))
+	if err != nil {
+		return false
+	}
+	return pyprojectUsesPDM(string(content))
+}
+
+// toolchainFor names the dependency manager used to upgrade a repository.
+func toolchainFor(hasPDM bool) string {
+	if hasPDM {
+		return toolchainPDM
+	}
+	return toolchainPip
 }
 
 // parsePythonVersionFile extracts the Python version from a .python-version
@@ -535,6 +612,9 @@ func buildUpgradeScript(
 	// Python upgrade commands
 	writePythonUpgradeCommands(&sb, params)
 
+	// Keep generated build metadata out of the commit
+	writeEggInfoGitignore(&sb)
+
 	// Update Dockerfile python image tags
 	writeDockerfileUpdate(&sb)
 
@@ -601,6 +681,16 @@ func writePythonUpgradeCommands(sb *strings.Builder, params upgradeParams) {
 	sb.WriteString("source \"$VENV_DIR/bin/activate\"\n")
 	sb.WriteString("pip install --upgrade pip 2>&1 || echo \"WARNING: pip upgrade had some errors\"\n\n")
 
+	// A PDM-managed project is upgraded exclusively through PDM: pip has no
+	// view of the PDM lock file, so running both would leave the lock stale
+	// while still producing the local-install artefacts pip leaves behind.
+	if params.HasPDM {
+		writePDMUpgradeCommands(sb)
+		sb.WriteString("deactivate 2>/dev/null || true\n")
+		sb.WriteString("rm -rf \"$VENV_DIR\"\n\n")
+		return
+	}
+
 	if params.HasRequirements {
 		sb.WriteString("# Upgrade dependencies from requirements.txt\n")
 		sb.WriteString("if [ -f \"requirements.txt\" ]; then\n")
@@ -630,6 +720,48 @@ func writePythonUpgradeCommands(sb *strings.Builder, params upgradeParams) {
 
 	sb.WriteString("deactivate 2>/dev/null || true\n")
 	sb.WriteString("rm -rf \"$VENV_DIR\"\n\n")
+}
+
+// writePDMUpgradeCommands emits the upgrade step for a PDM-managed project.
+//
+// `--no-sync` keeps the run to a dependency resolution: the updated pdm.lock is
+// the only artefact worth committing, and skipping the sync also avoids
+// building the project locally — the build is what leaves a *.egg-info
+// directory behind for `git add -A` to sweep into the commit.
+//
+// The `-G :all` form covers every optional-dependency group; projects that
+// declare none reject it, so the plain form is retried before giving up.
+func writePDMUpgradeCommands(sb *strings.Builder) {
+	sb.WriteString("# Upgrade dependencies with PDM (project is PDM-managed)\n")
+	sb.WriteString("if ! command -v pdm > /dev/null 2>&1; then\n")
+	sb.WriteString("    echo \"Installing PDM into the temporary virtual environment...\"\n")
+	sb.WriteString("    pip install --upgrade pdm 2>&1 || echo \"WARNING: PDM installation had some errors\"\n")
+	sb.WriteString("fi\n")
+	sb.WriteString("echo \"Running pdm update...\"\n")
+	sb.WriteString("pdm update --update-all --no-sync -G :all 2>&1 \\\n")
+	sb.WriteString("    || pdm update --update-all --no-sync 2>&1 \\\n")
+	sb.WriteString("    || echo \"WARNING: pdm update had some errors (continuing anyway)\"\n\n")
+}
+
+// writeEggInfoGitignore appends the setuptools build-metadata pattern to
+// .gitignore when the upgrade left an *.egg-info directory behind. Those files
+// are generated, so without the entry they are untracked-but-not-ignored and
+// the `git add -A` further down commits them as though they were a dependency
+// change. The entry is only added when such a directory actually exists, so
+// repositories that never build the project keep their .gitignore untouched.
+func writeEggInfoGitignore(sb *strings.Builder) {
+	sb.WriteString("# Ignore setuptools build metadata so it is never committed as a change.\n")
+	sb.WriteString("if ls -d ./*.egg-info > /dev/null 2>&1; then\n")
+	sb.WriteString("    if ! grep -qE '^\\*\\.egg-info/?$' .gitignore 2>/dev/null; then\n")
+	sb.WriteString("        echo \"Adding *.egg-info/ to .gitignore...\"\n")
+	// A .gitignore whose last line lacks a trailing newline would otherwise
+	// have the new pattern appended onto the end of that line.
+	sb.WriteString("        if [ -s .gitignore ] && [ -n \"$(tail -c1 .gitignore)\" ]; then\n")
+	sb.WriteString("            echo \"\" >> .gitignore\n")
+	sb.WriteString("        fi\n")
+	sb.WriteString("        echo \"*.egg-info/\" >> .gitignore\n")
+	sb.WriteString("    fi\n")
+	sb.WriteString("fi\n\n")
 }
 
 func writeDockerfileUpdate(sb *strings.Builder) {
@@ -735,29 +867,40 @@ func findPythonBinary() (string, error) {
 
 // GeneratePRDescription builds a markdown PR description for a Python
 // dependency upgrade. Exported so that the local-mode CLI handler can
-// reuse the same description format.
-func GeneratePRDescription(pyVersion string, pyVersionUpdated bool) string {
+// reuse the same description format. The toolchain ("pdm" or "pip") selects
+// the commands and the review target named in the body, so the description
+// always reports what the run actually did.
+func GeneratePRDescription(pyVersion, toolchain string, pyVersionUpdated bool) string {
 	var sb strings.Builder
 	sb.WriteString("## Summary\n\n")
 	if pyVersionUpdated {
 		sb.WriteString(
-			"This PR upgrades the Python version to **" + pyVersion + "** and updates all pip dependencies.\n\n",
+			"This PR upgrades the Python version to **" + pyVersion +
+				"** and updates all " + toolchain + " dependencies.\n\n",
 		)
 	} else {
 		sb.WriteString(
-			"This PR updates all Python pip dependencies to their latest versions.\n\n",
+			"This PR updates all Python " + toolchain + " dependencies to their latest versions.\n\n",
 		)
 	}
 	sb.WriteString("### Changes\n\n")
 	if pyVersionUpdated {
 		sb.WriteString("- Updated `.python-version` to `" + pyVersion + "`\n")
 	}
-	sb.WriteString("- Ran `pip install --upgrade -r requirements.txt` to update all dependencies\n")
-	sb.WriteString("- Ran `pip freeze` to capture updated versions\n")
+	if toolchain == toolchainPDM {
+		sb.WriteString("- Ran `pdm update --update-all --no-sync` to resolve the latest dependency versions\n")
+	} else {
+		sb.WriteString("- Ran `pip install --upgrade -r requirements.txt` to update all dependencies\n")
+		sb.WriteString("- Ran `pip freeze` to capture updated versions\n")
+	}
 	sb.WriteString("\n### Review Checklist\n\n")
 	sb.WriteString("- [ ] Verify build passes\n")
 	sb.WriteString("- [ ] Verify tests pass\n")
-	sb.WriteString("- [ ] Review dependency changes in `requirements.txt`\n")
+	if toolchain == toolchainPDM {
+		sb.WriteString("- [ ] Review dependency changes in `pdm.lock`\n")
+	} else {
+		sb.WriteString("- [ ] Review dependency changes in `requirements.txt`\n")
+	}
 	sb.WriteString("\n---\n")
 	sb.WriteString("*This PR was automatically created by [autoupdate](https://github.com/rios0rios0/autoupdate)*\n")
 	return sb.String()

--- a/internal/infrastructure/repositories/python/python_updater_repository_test.go
+++ b/internal/infrastructure/repositories/python/python_updater_repository_test.go
@@ -326,7 +326,7 @@ func TestGeneratePRDescription(t *testing.T) {
 		t.Parallel()
 
 		// given / when
-		result := pyUpdater.GeneratePRDescription("3.13.1", true)
+		result := pyUpdater.GeneratePRDescription("3.13.1", "pip", true)
 
 		// then
 		assert.Contains(t, result, "3.13.1")
@@ -337,7 +337,7 @@ func TestGeneratePRDescription(t *testing.T) {
 		t.Parallel()
 
 		// given / when
-		result := pyUpdater.GeneratePRDescription("3.13.1", false)
+		result := pyUpdater.GeneratePRDescription("3.13.1", "pip", false)
 
 		// then
 		assert.Contains(t, result, "dependencies")
@@ -421,7 +421,7 @@ func TestBuildBatchPythonScript(t *testing.T) {
 		t.Parallel()
 
 		// given / when
-		script := pyUpdater.BuildBatchPythonScript(true, true)
+		script := pyUpdater.BuildBatchPythonScript(true, true, false)
 
 		// then
 		assert.True(t, strings.HasPrefix(script, "#!/bin/bash\n"))
@@ -434,7 +434,7 @@ func TestBuildBatchPythonScript(t *testing.T) {
 		t.Parallel()
 
 		// given / when
-		script := pyUpdater.BuildBatchPythonScript(false, true)
+		script := pyUpdater.BuildBatchPythonScript(false, true, false)
 
 		// then
 		assert.NotContains(t, script, "pip install -r requirements.txt")
@@ -445,7 +445,7 @@ func TestBuildBatchPythonScript(t *testing.T) {
 		t.Parallel()
 
 		// given / when
-		script := pyUpdater.BuildBatchPythonScript(true, false)
+		script := pyUpdater.BuildBatchPythonScript(true, false, false)
 
 		// then
 		assert.Contains(t, script, "pip install -r requirements.txt")
@@ -456,7 +456,7 @@ func TestBuildBatchPythonScript(t *testing.T) {
 		t.Parallel()
 
 		// given / when
-		script := pyUpdater.BuildBatchPythonScript(false, false)
+		script := pyUpdater.BuildBatchPythonScript(false, false, false)
 
 		// then
 		assert.Contains(t, script, "set -euo pipefail")
@@ -1450,5 +1450,259 @@ func TestRunLanguageUpgradeScript(t *testing.T) { //nolint:paralleltest // mutat
 		// then
 		require.NoError(t, err)
 		assert.Equal(t, "verbose output\n", output)
+	})
+}
+
+func TestPyprojectUsesPDM(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should detect a project configured through a tool.pdm table", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := "[project]\nname = \"demo\"\n\n[tool.pdm.dev-dependencies]\ntest = [\"pytest\"]\n"
+
+		// when
+		detected := pyUpdater.PyprojectUsesPDM(content)
+
+		// then
+		assert.True(t, detected)
+	})
+
+	t.Run("should detect a project built with the pdm backend", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := "[build-system]\nrequires = [\"pdm-backend\"]\nbuild-backend = \"pdm.backend\"\n"
+
+		// when
+		detected := pyUpdater.PyprojectUsesPDM(content)
+
+		// then
+		assert.True(t, detected)
+	})
+
+	t.Run("should not detect a setuptools project", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := "[build-system]\nrequires = [\"setuptools\"]\nbuild-backend = \"setuptools.build_meta\"\n"
+
+		// when
+		detected := pyUpdater.PyprojectUsesPDM(content)
+
+		// then
+		assert.False(t, detected)
+	})
+
+	t.Run("should ignore markers that appear only inside comments", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := "[project]\nname = \"demo\"\n# migrate to [tool.pdm] one day\n"
+
+		// when
+		detected := pyUpdater.PyprojectUsesPDM(content)
+
+		// then
+		assert.False(t, detected)
+	})
+}
+
+func TestHasPDMLocal(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should detect PDM from a lock file alone", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repoDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(repoDir, "pdm.lock"), []byte("[metadata]\n"), 0o600))
+
+		// when
+		detected := pyUpdater.HasPDMLocal(repoDir)
+
+		// then
+		assert.True(t, detected)
+	})
+
+	t.Run("should detect PDM from pyproject markers when no lock file exists", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repoDir := t.TempDir()
+		require.NoError(t, os.WriteFile(
+			filepath.Join(repoDir, "pyproject.toml"), []byte("[tool.pdm]\n"), 0o600,
+		))
+
+		// when
+		detected := pyUpdater.HasPDMLocal(repoDir)
+
+		// then
+		assert.True(t, detected)
+	})
+
+	t.Run("should not detect PDM in a plain pip project", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		repoDir := t.TempDir()
+		require.NoError(t, os.WriteFile(
+			filepath.Join(repoDir, "pyproject.toml"), []byte("[project]\nname = \"demo\"\n"), 0o600,
+		))
+
+		// when
+		detected := pyUpdater.HasPDMLocal(repoDir)
+
+		// then
+		assert.False(t, detected)
+	})
+}
+
+func TestHasPDMRemote(t *testing.T) {
+	t.Parallel()
+
+	repo := entities.Repository{Organization: "org", Name: "repo"}
+
+	t.Run("should detect PDM when the remote carries a lock file", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{"pdm.lock": true}).
+			BuildSpy()
+
+		// when
+		detected := pyUpdater.HasPDMRemote(t.Context(), provider, repo)
+
+		// then
+		assert.True(t, detected)
+	})
+
+	t.Run("should detect PDM from the remote pyproject when no lock file exists", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{"pyproject.toml": true}).
+			WithFileContents(map[string]string{"pyproject.toml": "[tool.pdm]\n"}).
+			BuildSpy()
+
+		// when
+		detected := pyUpdater.HasPDMRemote(t.Context(), provider, repo)
+
+		// then
+		assert.True(t, detected)
+	})
+
+	t.Run("should not detect PDM when the remote pyproject is unreadable", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{"pyproject.toml": true}).
+			WithFileContentErr(errors.New("not found")).
+			BuildSpy()
+
+		// when
+		detected := pyUpdater.HasPDMRemote(t.Context(), provider, repo)
+
+		// then
+		assert.False(t, detected)
+	})
+}
+
+func TestBuildBatchPythonScriptWithPDM(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should upgrade through PDM when the project is PDM-managed", func(t *testing.T) {
+		t.Parallel()
+
+		// given / when
+		script := pyUpdater.BuildBatchPythonScript(false, true, true)
+
+		// then
+		assert.Contains(t, script, "pdm update --update-all --no-sync")
+		assert.Contains(t, script, "pip install --upgrade pdm")
+	})
+
+	t.Run("should not run the pip local install for a PDM project", func(t *testing.T) {
+		t.Parallel()
+
+		// given / when
+		script := pyUpdater.BuildBatchPythonScript(true, true, true)
+
+		// then
+		assert.NotContains(t, script, "pip install --upgrade .")
+		assert.NotContains(t, script, "pip install -r requirements.txt")
+	})
+
+	t.Run("should keep using pip when the project is not PDM-managed", func(t *testing.T) {
+		t.Parallel()
+
+		// given / when
+		script := pyUpdater.BuildBatchPythonScript(false, true, false)
+
+		// then
+		assert.Contains(t, script, "pip install --upgrade .")
+		assert.NotContains(t, script, "pdm update")
+	})
+}
+
+func TestWriteEggInfoGitignore(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should append the egg-info pattern guarded by an existence check", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		var sb strings.Builder
+
+		// when
+		pyUpdater.WriteEggInfoGitignore(&sb)
+		script := sb.String()
+
+		// then
+		assert.Contains(t, script, "ls -d ./*.egg-info")
+		assert.Contains(t, script, "echo \"*.egg-info/\" >> .gitignore")
+		assert.Contains(t, script, "grep -qE '^\\*\\.egg-info/?$' .gitignore")
+	})
+
+	t.Run("should be part of the batch script so artefacts never reach a commit", func(t *testing.T) {
+		t.Parallel()
+
+		// given / when
+		script := pyUpdater.BuildBatchPythonScript(false, true, false)
+
+		// then
+		assert.Contains(t, script, "*.egg-info/")
+	})
+}
+
+func TestGeneratePRDescriptionToolchain(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should describe the PDM commands and lock file for a PDM project", func(t *testing.T) {
+		t.Parallel()
+
+		// given / when
+		result := pyUpdater.GeneratePRDescription("3.13.1", "pdm", false)
+
+		// then
+		assert.Contains(t, result, "pdm update --update-all --no-sync")
+		assert.Contains(t, result, "`pdm.lock`")
+		assert.NotContains(t, result, "requirements.txt")
+	})
+
+	t.Run("should describe the pip commands and requirements file for a pip project", func(t *testing.T) {
+		t.Parallel()
+
+		// given / when
+		result := pyUpdater.GeneratePRDescription("3.13.1", "pip", false)
+
+		// then
+		assert.Contains(t, result, "pip install --upgrade -r requirements.txt")
+		assert.Contains(t, result, "`requirements.txt`")
+		assert.NotContains(t, result, "pdm")
 	})
 }

--- a/internal/infrastructure/repositories/python/python_updater_repository_test.go
+++ b/internal/infrastructure/repositories/python/python_updater_repository_test.go
@@ -1507,6 +1507,72 @@ func TestPyprojectUsesPDM(t *testing.T) {
 		// then
 		assert.False(t, detected)
 	})
+
+	t.Run("should ignore a marker named only in a trailing inline comment", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := "[build-system]\nbuild-backend = \"setuptools.build_meta\" # pdm.backend\n"
+
+		// when
+		detected := pyUpdater.PyprojectUsesPDM(content)
+
+		// then
+		assert.False(t, detected)
+	})
+
+	t.Run("should ignore a table only named in a trailing inline comment", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := "[project]\nname = \"demo\" # unlike [tool.pdm] projects\n"
+
+		// when
+		detected := pyUpdater.PyprojectUsesPDM(content)
+
+		// then
+		assert.False(t, detected)
+	})
+
+	t.Run("should not treat an unrelated table sharing the prefix as PDM", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := "[tool.pdmx]\nsetting = 1\n"
+
+		// when
+		detected := pyUpdater.PyprojectUsesPDM(content)
+
+		// then
+		assert.False(t, detected)
+	})
+
+	t.Run("should still detect a marker followed by an inline comment", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := "[build-system]\nbuild-backend = \"pdm.backend\" # the PDM build backend\n"
+
+		// when
+		detected := pyUpdater.PyprojectUsesPDM(content)
+
+		// then
+		assert.True(t, detected)
+	})
+
+	t.Run("should not mistake a hash inside a quoted value for a comment", func(t *testing.T) {
+		t.Parallel()
+
+		// given — the '#' belongs to the value, so the [tool.pdm] table that
+		// follows must still be reached.
+		content := "[project]\nname = \"demo#1\"\n[tool.pdm]\n"
+
+		// when
+		detected := pyUpdater.PyprojectUsesPDM(content)
+
+		// then
+		assert.True(t, detected)
+	})
 }
 
 func TestHasPDMLocal(t *testing.T) {


### PR DESCRIPTION
## Summary

The Python updater drove every project through raw pip. For a PDM-managed project that is a no-op on the thing that matters: pip has no view of `pdm.lock`, so the file the project actually resolves against was never refreshed no matter how often the updater ran.

Worse, the `pyproject.toml` branch ran `pip install --upgrade .`, which builds the project locally and makes setuptools emit a `*.egg-info/` directory. Because those generated files were untracked but not ignored, `git add -A` swept them into the commit — so a repository with **no dependency movement at all** still produced a pull request whose entire diff was build metadata.

## Changes

- **Detects PDM** from any of three markers: a `pdm.lock`, a `[tool.pdm]` table, or the `pdm.backend` build backend. Detection works in remote, batch and local modes; markers appearing only inside comments are ignored.
- **Upgrades PDM projects with PDM** instead of pip:
  ```
  pdm update --update-all --no-sync -G :all
      || pdm update --update-all --no-sync
      || echo "WARNING: ..."
  ```
  `--no-sync` is deliberate — the refreshed `pdm.lock` is the only artefact worth committing, and skipping the sync also avoids building the project, which is what leaves `*.egg-info/` behind. PDM is installed into the throwaway virtualenv when it is not already on `PATH`. The `-G :all` form covers optional-dependency groups, with the plain form as a fallback.
- **Adds `*.egg-info/` to `.gitignore`**, and only when such a directory actually exists, so repositories that never build the project keep their `.gitignore` untouched.
- **Names the dependency manager actually used** in the PR description and changelog entry. The description previously advertised `pip install --upgrade -r requirements.txt` and asked reviewers to review `requirements.txt` even for projects that have no such file.

A PDM project is now upgraded exclusively through PDM — running both would leave the lock stale while still producing pip's local-install artefacts.

## Verification

- `pdm update --update-all --no-sync -G :all` exercised against a real PDM project: exits `0` and produces **no** `egg-info` directory.
- The generated `.gitignore` step was extracted and run under `set -euo pipefail` across six cases — all exit `0`: no artefact present (file left untouched/absent), artefact with no `.gitignore` (created), artefact with a trailing newline (appended), artefact **without** a trailing newline (blank line inserted first, no line-joining), and entry already present (no duplicate).
- Both generated scripts pass `bash -n`.
- `make lint` 0 issues · `make test` green · `make sast` clean (CodeQL 0, Semgrep 0/117 rules, Trivy 0, Gitleaks no leaks).

## Review Checklist

- [ ] `--no-sync` is the right default — the lock is refreshed, but no environment is installed
- [ ] The `-G :all` fallback chain is acceptable for projects that declare no optional groups
- [ ] Adding to `.gitignore` (rather than deleting the directory) is the preferred remedy

## Follow-up, not in this PR

This makes PDM projects resolve correctly, but it does not yet suppress a pull request when nothing actually moved. Gating the commit on "the manifest or lock changed" rather than "the working tree is dirty" is a separate change.
