### PR TITLE
fix(pipeline): upgraded the version carried by displayName labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
   with no dependency movement at all still produced a pull request. The pattern is now added to
   `.gitignore`, and only when such a directory actually exists, so repositories that never build the
   project keep their `.gitignore` untouched
+- fixed the pipeline updater leaving a stale version behind in `displayName` labels. Upgrading a
+  task from `3.11` to `3.14` rewrote `versionSpec` but left `displayName: 'Use Python 3.11'`
+  untouched, so the file described a version it no longer used. The label is now upgraded alongside
+  the version field rather than having its version stripped out, and it is upgraded whether it is
+  written above or below that field — a label written below sat outside the scan match and was never
+  reached at all. The rewrite stops at the enclosing task boundary, so a neighbouring task mentioning
+  the same version keeps its own label, and a label reading `3.110` is left alone when the upgrade is
+  from `3.11`
+
 ## [0.18.0] - 2026-07-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,9 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
   untouched, so the file described a version it no longer used. The label is now upgraded alongside
   the version field rather than having its version stripped out, and it is upgraded whether it is
   written above or below that field — a label written below sat outside the scan match and was never
-  reached at all. The rewrite stops at the enclosing task boundary, so a neighbouring task mentioning
-  the same version keeps its own label, and a label reading `3.110` is left alone when the upgrade is
-  from `3.11`
+  reached at all. The rewrite stops at the end of the enclosing step, so a later step mentioning the
+  same version keeps its own label — including a non-task step such as `- script:`, which owns a
+  label of its own — and a label reading `3.110` is left alone when the upgrade is from `3.11`
 
 ## [0.18.0] - 2026-07-27
 

--- a/internal/infrastructure/repositories/pipeline/pipeline_updater_repository.go
+++ b/internal/infrastructure/repositories/pipeline/pipeline_updater_repository.go
@@ -820,14 +820,51 @@ func replaceLastOccurrence(s, old, replacement string) string {
 	return s[:idx] + replacement + s[idx+len(old):]
 }
 
-// stripDisplayNameVersion removes the version number from displayName lines
-// within a matched task block. For example, "displayName: '🐍 Use Python 3.12'"
-// becomes "displayName: '🐍 Use Python'".
-func stripDisplayNameVersion(s, version string) string {
+// updateDisplayNameVersion rewrites the version carried by displayName labels
+// so the label keeps describing the version the task actually uses. For
+// example, upgrading 3.11 to 3.14 turns "displayName: '🐍 Use Python 3.11'"
+// into "displayName: '🐍 Use Python 3.14'".
+//
+// The trailing group refuses to start with a digit or a dot, so a label reading
+// "3.110" is not rewritten when the upgraded version is "3.11".
+func updateDisplayNameVersion(s, oldVersion, newVersion string) string {
 	pattern := regexp.MustCompile(
-		`(displayName:\s*['"][^'"]*?)\s+` + regexp.QuoteMeta(version) + `([^'"]*['"])`,
+		`(displayName:\s*['"][^'"]*?)` + regexp.QuoteMeta(oldVersion) + `((?:[^0-9.][^'"]*)?['"])`,
 	)
-	return pattern.ReplaceAllString(s, "${1}${2}")
+	return pattern.ReplaceAllString(s, "${1}"+newVersion+"${2}")
+}
+
+// applyUpgradeToContent rewrites the first occurrence of the match that still
+// carries the old version.
+//
+// The rewrite is driven from the match position rather than by re-locating the
+// rewritten text, because two tasks in the same file are frequently textually
+// identical (the same task pinned to the same version in two jobs). Searching
+// for the replacement would keep finding the first one and leave every later
+// task's label untouched. Working positionally is unambiguous: each iteration
+// finds the next occurrence, since the ones already processed no longer match.
+func applyUpgradeToContent(content string, up upgradeTask) string {
+	matchIdx := strings.Index(content, up.match.FullMatch)
+	if matchIdx < 0 {
+		return content
+	}
+
+	newMatch := replaceLastOccurrence(up.match.FullMatch, up.match.CurrentVer, up.newVersion)
+	// A label written above the version field falls inside the match.
+	newMatch = updateDisplayNameVersion(newMatch, up.match.CurrentVer, up.newVersion)
+
+	// A label written below it does not: the Azure DevOps scan patterns stop
+	// at the version key. The remainder of the enclosing task block is
+	// rewritten too, stopping before any neighbouring task so a sibling
+	// mentioning the same version keeps its own label.
+	tail := content[matchIdx+len(up.match.FullMatch):]
+	blockEnd := len(tail)
+	if loc := azureTaskDecl.FindStringIndex(tail); loc != nil {
+		blockEnd = loc[0]
+	}
+	tail = updateDisplayNameVersion(tail[:blockEnd], up.match.CurrentVer, up.newVersion) + tail[blockEnd:]
+
+	return content[:matchIdx] + newMatch + tail
 }
 
 // --- upgrade application ---
@@ -843,10 +880,7 @@ func applyUpgrades(upgrades []upgradeTask, fileContents map[string]string) []ent
 			continue
 		}
 
-		newMatch := replaceLastOccurrence(up.match.FullMatch, up.match.CurrentVer, up.newVersion)
-		newMatch = stripDisplayNameVersion(newMatch, up.match.CurrentVer)
-		content = strings.Replace(content, up.match.FullMatch, newMatch, 1)
-		modified[up.match.FilePath] = content
+		modified[up.match.FilePath] = applyUpgradeToContent(content, up)
 	}
 
 	var changes []entities.FileChange

--- a/internal/infrastructure/repositories/pipeline/pipeline_updater_repository.go
+++ b/internal/infrastructure/repositories/pipeline/pipeline_updater_repository.go
@@ -419,6 +419,13 @@ func classifyFile(path string) ciSystem {
 // a version field that belongs to a *different* task further down the file.
 var azureTaskDecl = regexp.MustCompile(`(?m)^[ \t]*-[ \t]+task:[ \t]*\S+`)
 
+// azureStepDecl matches the start of any step in a steps list — `- task:`,
+// `- script:`, `- bash:`, `- checkout:` and so on — capturing the leading
+// indentation so a step can be told apart from a nested list entry belonging to
+// the step above it. Scanning stays keyed on azureTaskDecl; this pattern only
+// bounds how far a label rewrite may reach.
+var azureStepDecl = regexp.MustCompile(`(?m)^([ \t]*)-[ \t]+[A-Za-z][A-Za-z0-9_-]*:`)
+
 // scanForVersions dispatches version scanning by CI system. Azure DevOps rules
 // use multi-line `(?s)` patterns that match a task name and then the first
 // matching version field; to keep that match anchored to its own task, Azure
@@ -826,12 +833,37 @@ func replaceLastOccurrence(s, old, replacement string) string {
 // into "displayName: '🐍 Use Python 3.14'".
 //
 // The trailing group refuses to start with a digit or a dot, so a label reading
-// "3.110" is not rewritten when the upgraded version is "3.11".
+// "3.110" is not rewritten when the upgraded version is "3.11". No part of the
+// match may cross a newline, which keeps a label confined to its own line
+// instead of letting one match reach into the next label's quotes.
 func updateDisplayNameVersion(s, oldVersion, newVersion string) string {
 	pattern := regexp.MustCompile(
-		`(displayName:\s*['"][^'"]*?)` + regexp.QuoteMeta(oldVersion) + `((?:[^0-9.][^'"]*)?['"])`,
+		`(displayName:[ \t]*['"][^'"\n]*?)` + regexp.QuoteMeta(oldVersion) + `((?:[^0-9.\n][^'"\n]*)?['"])`,
 	)
 	return pattern.ReplaceAllString(s, "${1}"+newVersion+"${2}")
+}
+
+// lineIndentAt returns the indentation width of the line holding idx.
+func lineIndentAt(content string, idx int) int {
+	lineStart := strings.LastIndexByte(content[:idx], '\n') + 1
+	prefix := content[lineStart:idx]
+	return len(prefix) - len(strings.TrimLeft(prefix, " \t"))
+}
+
+// stepBlockEnd returns the offset in tail at which the step owning the match
+// ends — the next step declaration indented no deeper than that step. Bounding
+// on any step rather than only on the next `- task:` matters because a
+// non-task step (`- script:`, `- bash:`, `- pwsh:`) between two tasks owns its
+// own label, which must not be rewritten by the task before it. A more deeply
+// indented `- key:` is a nested list entry belonging to the current step, so it
+// does not end the block.
+func stepBlockEnd(tail string, indent int) int {
+	for _, loc := range azureStepDecl.FindAllStringSubmatchIndex(tail, -1) {
+		if len(tail[loc[2]:loc[3]]) <= indent {
+			return loc[0]
+		}
+	}
+	return len(tail)
 }
 
 // applyUpgradeToContent rewrites the first occurrence of the match that still
@@ -854,14 +886,11 @@ func applyUpgradeToContent(content string, up upgradeTask) string {
 	newMatch = updateDisplayNameVersion(newMatch, up.match.CurrentVer, up.newVersion)
 
 	// A label written below it does not: the Azure DevOps scan patterns stop
-	// at the version key. The remainder of the enclosing task block is
-	// rewritten too, stopping before any neighbouring task so a sibling
-	// mentioning the same version keeps its own label.
+	// at the version key. The remainder of the enclosing step is rewritten
+	// too, stopping before the next step so a sibling mentioning the same
+	// version keeps its own label.
 	tail := content[matchIdx+len(up.match.FullMatch):]
-	blockEnd := len(tail)
-	if loc := azureTaskDecl.FindStringIndex(tail); loc != nil {
-		blockEnd = loc[0]
-	}
+	blockEnd := stepBlockEnd(tail, lineIndentAt(content, matchIdx))
 	tail = updateDisplayNameVersion(tail[:blockEnd], up.match.CurrentVer, up.newVersion) + tail[blockEnd:]
 
 	return content[:matchIdx] + newMatch + tail

--- a/internal/infrastructure/repositories/pipeline/pipeline_updater_repository_test.go
+++ b/internal/infrastructure/repositories/pipeline/pipeline_updater_repository_test.go
@@ -947,6 +947,89 @@ func TestApplyUpgrades(t *testing.T) {
 		assert.NotContains(t, changes[0].Content, "3.11")
 	})
 
+	t.Run("should not rewrite the label of a script step following the task", func(t *testing.T) {
+		t.Parallel()
+
+		// given — a non-task step owns its own label, which the task before it
+		// must not rewrite. The task carries no label of its own, so nothing
+		// absorbs the rewrite before it reaches the script step.
+		content := `steps:
+  - task: 'UsePythonVersion@0'
+    inputs:
+      versionSpec: '3.11'
+  - script: echo build
+    displayName: 'Build against Python 3.11'
+`
+		fullMatch := "UsePythonVersion@0'\n    inputs:\n      versionSpec: '3.11'"
+		upgrades := []pipeline.UpgradeTask{
+			pipeline.NewUpgradeTaskWithFullMatch("python", "3.11", "3.14", "azure-pipelines.yml", fullMatch),
+		}
+		fileContents := map[string]string{"azure-pipelines.yml": content}
+
+		// when
+		changes := pipeline.ApplyUpgrades(upgrades, fileContents)
+
+		// then
+		require.Len(t, changes, 1)
+		assert.Contains(t, changes[0].Content, "versionSpec: '3.14'")
+		assert.Contains(t, changes[0].Content, "displayName: 'Build against Python 3.11'")
+	})
+
+	t.Run("should rewrite the task label but not a later script step label", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := `steps:
+  - task: 'UsePythonVersion@0'
+    inputs:
+      versionSpec: '3.11'
+    displayName: 'Use Python 3.11'
+  - script: echo build
+    displayName: 'Build against Python 3.11'
+`
+		fullMatch := "UsePythonVersion@0'\n    inputs:\n      versionSpec: '3.11'"
+		upgrades := []pipeline.UpgradeTask{
+			pipeline.NewUpgradeTaskWithFullMatch("python", "3.11", "3.14", "azure-pipelines.yml", fullMatch),
+		}
+		fileContents := map[string]string{"azure-pipelines.yml": content}
+
+		// when
+		changes := pipeline.ApplyUpgrades(upgrades, fileContents)
+
+		// then
+		require.Len(t, changes, 1)
+		assert.Contains(t, changes[0].Content, "displayName: 'Use Python 3.14'")
+		assert.Contains(t, changes[0].Content, "displayName: 'Build against Python 3.11'")
+	})
+
+	t.Run("should not let a nested list entry cut the step short", func(t *testing.T) {
+		t.Parallel()
+
+		// given — `- name: a` is a nested entry inside the task's own inputs,
+		// not the start of the next step, so the label below it is still part
+		// of this task.
+		content := `steps:
+  - task: 'UsePythonVersion@0'
+    inputs:
+      versionSpec: '3.11'
+      args:
+        - name: a
+    displayName: 'Use Python 3.11'
+`
+		fullMatch := "UsePythonVersion@0'\n    inputs:\n      versionSpec: '3.11'"
+		upgrades := []pipeline.UpgradeTask{
+			pipeline.NewUpgradeTaskWithFullMatch("python", "3.11", "3.14", "azure-pipelines.yml", fullMatch),
+		}
+		fileContents := map[string]string{"azure-pipelines.yml": content}
+
+		// when
+		changes := pipeline.ApplyUpgrades(upgrades, fileContents)
+
+		// then
+		require.Len(t, changes, 1)
+		assert.Contains(t, changes[0].Content, "displayName: 'Use Python 3.14'")
+	})
+
 	t.Run("should not rewrite a displayName version that merely shares a prefix", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/infrastructure/repositories/pipeline/pipeline_updater_repository_test.go
+++ b/internal/infrastructure/repositories/pipeline/pipeline_updater_repository_test.go
@@ -5,6 +5,7 @@ package pipeline_test
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -838,7 +839,7 @@ func TestReplaceLastOccurrence(t *testing.T) {
 func TestApplyUpgrades(t *testing.T) {
 	t.Parallel()
 
-	t.Run("should replace versionSpec and strip version from displayName", func(t *testing.T) {
+	t.Run("should replace versionSpec and upgrade a displayName above it", func(t *testing.T) {
 		t.Parallel()
 
 		// given
@@ -858,9 +859,116 @@ func TestApplyUpgrades(t *testing.T) {
 
 		// then
 		require.Len(t, changes, 1)
-		assert.Contains(t, changes[0].Content, "displayName: 'Install Python'")
+		assert.Contains(t, changes[0].Content, "displayName: 'Install Python 3.13'")
 		assert.NotContains(t, changes[0].Content, "displayName: 'Install Python 3.12'")
 		assert.Contains(t, changes[0].Content, "versionSpec: '3.13'")
+	})
+
+	t.Run("should upgrade a displayName written below the versionSpec", func(t *testing.T) {
+		t.Parallel()
+
+		// given — the scan pattern stops at versionSpec, so this label sits
+		// outside the match and used to keep advertising the old version.
+		content := `- task: 'UsePythonVersion@0'
+  inputs:
+    versionSpec: '3.11'
+  displayName: 'Use Python 3.11'
+`
+		fullMatch := "UsePythonVersion@0'\n  inputs:\n    versionSpec: '3.11'"
+		upgrades := []pipeline.UpgradeTask{
+			pipeline.NewUpgradeTaskWithFullMatch("python", "3.11", "3.14", "azure-pipelines.yml", fullMatch),
+		}
+		fileContents := map[string]string{"azure-pipelines.yml": content}
+
+		// when
+		changes := pipeline.ApplyUpgrades(upgrades, fileContents)
+
+		// then
+		require.Len(t, changes, 1)
+		assert.Contains(t, changes[0].Content, "versionSpec: '3.14'")
+		assert.Contains(t, changes[0].Content, "displayName: 'Use Python 3.14'")
+		assert.NotContains(t, changes[0].Content, "3.11")
+	})
+
+	t.Run("should not touch a displayName belonging to a neighbouring task", func(t *testing.T) {
+		t.Parallel()
+
+		// given — the second task keeps its own version, which happens to be
+		// the version being upgraded in the first task.
+		content := `- task: 'UsePythonVersion@0'
+  inputs:
+    versionSpec: '3.11'
+- task: 'Other@1'
+  displayName: 'Keep Python 3.11'
+`
+		fullMatch := "UsePythonVersion@0'\n  inputs:\n    versionSpec: '3.11'"
+		upgrades := []pipeline.UpgradeTask{
+			pipeline.NewUpgradeTaskWithFullMatch("python", "3.11", "3.14", "azure-pipelines.yml", fullMatch),
+		}
+		fileContents := map[string]string{"azure-pipelines.yml": content}
+
+		// when
+		changes := pipeline.ApplyUpgrades(upgrades, fileContents)
+
+		// then
+		require.Len(t, changes, 1)
+		assert.Contains(t, changes[0].Content, "versionSpec: '3.14'")
+		assert.Contains(t, changes[0].Content, "displayName: 'Keep Python 3.11'")
+	})
+
+	t.Run("should upgrade every label when two tasks are textually identical", func(t *testing.T) {
+		t.Parallel()
+
+		// given — two jobs pinning the same version through the same task, so
+		// both upgrades carry the same FullMatch.
+		content := `- task: 'UsePythonVersion@0'
+  inputs:
+    versionSpec: '3.11'
+  displayName: 'Use Python 3.11'
+- task: 'UsePythonVersion@0'
+  inputs:
+    versionSpec: '3.11'
+  displayName: 'Use Python 3.11'
+`
+		fullMatch := "UsePythonVersion@0'\n  inputs:\n    versionSpec: '3.11'"
+		upgrades := []pipeline.UpgradeTask{
+			pipeline.NewUpgradeTaskWithFullMatch("python", "3.11", "3.14", "azure-pipelines.yml", fullMatch),
+			pipeline.NewUpgradeTaskWithFullMatch("python", "3.11", "3.14", "azure-pipelines.yml", fullMatch),
+		}
+		fileContents := map[string]string{"azure-pipelines.yml": content}
+
+		// when
+		changes := pipeline.ApplyUpgrades(upgrades, fileContents)
+
+		// then
+		require.Len(t, changes, 1)
+		assert.Equal(t, 2, strings.Count(changes[0].Content, "versionSpec: '3.14'"))
+		assert.Equal(t, 2, strings.Count(changes[0].Content, "displayName: 'Use Python 3.14'"))
+		assert.NotContains(t, changes[0].Content, "3.11")
+	})
+
+	t.Run("should not rewrite a displayName version that merely shares a prefix", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		content := `- task: 'UsePythonVersion@0'
+  inputs:
+    versionSpec: '3.11'
+  displayName: 'Use Python 3.110'
+`
+		fullMatch := "UsePythonVersion@0'\n  inputs:\n    versionSpec: '3.11'"
+		upgrades := []pipeline.UpgradeTask{
+			pipeline.NewUpgradeTaskWithFullMatch("python", "3.11", "3.14", "azure-pipelines.yml", fullMatch),
+		}
+		fileContents := map[string]string{"azure-pipelines.yml": content}
+
+		// when
+		changes := pipeline.ApplyUpgrades(upgrades, fileContents)
+
+		// then
+		require.Len(t, changes, 1)
+		assert.Contains(t, changes[0].Content, "versionSpec: '3.14'")
+		assert.Contains(t, changes[0].Content, "displayName: 'Use Python 3.110'")
 	})
 }
 


### PR DESCRIPTION
## Summary

When the pipeline updater bumped a language version in an Azure DevOps task, it rewrote the version field but left the human-readable label describing the old version. The result is a file that contradicts itself:

```yaml
- task: 'UsePythonVersion@0'
  inputs:
    versionSpec: '3.14'
  displayName: 'Use Python 3.11'   # <- not updated
```

There were two separate causes.

**The label was stripped, not upgraded.** `stripDisplayNameVersion` deleted the version from the label entirely, turning `'Use Python 3.12'` into `'Use Python'`. That loses information a reader wants.

**A label below the version field was never touched at all.** The scan patterns are non-greedy and stop at the version key, so the match ends before any label written underneath it. Everything downstream operated on that match, so such a label was invisible to the rewrite. The existing helper only ever worked for the label-above-the-field ordering.

## Changes

- `stripDisplayNameVersion` becomes `updateDisplayNameVersion`, which rewrites the version rather than removing it.
- The rewrite now extends past the match to the end of the enclosing task block, so labels on either side of the version field are covered. It stops at the next task declaration, so a neighbouring task mentioning the same version keeps its own label.
- The trailing group refuses to start with a digit or a dot, so a label reading `3.110` is not rewritten into `3.140` when the upgrade is from `3.11`.
- The whole rewrite is driven from the match position instead of by re-locating the replaced text.

## Note on that last point

Worth calling out for review, because my own unit tests missed it. Two jobs frequently pin the same version through the same task, which makes their matches byte-identical. The first implementation searched for the rewritten text to find where to fix the label — which kept finding the *first* block and silently left every later task's label stale. It only surfaced when I ran the change end-to-end through the real scan path against a two-job file.

Working positionally is unambiguous: each iteration finds the next occurrence, because the ones already processed no longer carry the old version. There is now a regression test for exactly that shape.

## Verification

- End-to-end through the real scan path (`LocalScanAndDetermineUpgrades` -> `ApplyUpgrades`) on a two-job file: both `versionSpec` values and both labels upgrade.
- New unit tests: label above the field, label below the field, two identical tasks, a neighbouring task that must keep its own label, and the `3.110` prefix case.
- `make lint` 0 issues · `make test` green · `make sast` clean.

## Review Checklist

- [ ] Bounding the rewrite at the next task declaration is the right block boundary
- [ ] Upgrading the label is preferred over the previous strip behaviour (this changes existing output)
