### PR TITLE
feat(chlog): added detection and fragment writing for chlog changelogs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -97,7 +97,7 @@ Cobra CLI (controllers) -> Commands (domain logic) -> Repositories (ports/adapte
 - **Domain commands**: `internal/domain/commands/` — `LocalCommand`, `RunCommand`, `SelfUpdateCommand`, `VersionCommand`
 - **Domain ports**: `internal/domain/repositories/` — `UpdaterRepository`, `LocalUpdater`, `ProviderRepository`, `SelfUpdateRepository`
 - **Infrastructure adapters**: `internal/infrastructure/repositories/` — updater implementations per ecosystem (terraform, golang, python, javascript, ruby, java, csharp, dockerfile, pipeline), plus `cmdrunner` (shared command execution), `gitlocal` (go-git operations), and `selfupdate`
-- **Support utilities**: `internal/support/` — filesystem helpers and remote file checker bridging `langforge` with `gitforge`
+- **Support utilities**: `internal/support/` — filesystem helpers, remote file checker bridging `langforge` with `gitforge`, and the shared changelog writer (`changelog.go`, `chlog.go`) every updater goes through
 - **Registries**: `provider_registry.go` (abstract factory for Git providers) and `updater_registry.go` (holds all updater implementations)
 
 ### Key External Libraries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,24 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added support for [chlog](https://github.com/luizjhonata/chlog), the fragment-based changelog
+  tool. A repository that commits a `.chlog.yaml` (or simply carries a `.changes/unreleased/`
+  directory) now gets one fragment file per update instead of an edit to the `[Unreleased]` section
+  of its `CHANGELOG.md`. chlog exists precisely to keep that file out of the merge path, so the
+  previous behaviour put automated pull requests back into conflict with every hand-written entry.
+  Detection is automatic, honours the `changesDir`, `unreleasedDir` and `kinds` declared by
+  `.chlog.yaml`, and covers every ecosystem in both local and batch mode. A repository that does not
+  use chlog is unaffected
+
+### Changed
+
+- changed the changelog handling of all nine ecosystems to run through one shared implementation
+  instead of a near-identical copy per ecosystem, so the two formats cannot drift apart. The bash
+  fragment the language updaters generate now takes its destination from the environment, which is
+  what lets the same script write either a `CHANGELOG.md` or a chlog fragment
+
 ## [0.19.0] - 2026-07-28
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Cobra CLI (controllers) -> Commands (domain logic) -> Repositories (ports/adapte
 - **Domain commands**: `internal/domain/commands/` — `LocalCommand` (single repo), `RunCommand` (batch mode), `SelfUpdateCommand`, and `VersionCommand`
 - **Domain ports**: `internal/domain/repositories/` — `UpdaterRepository`, `LocalUpdater`, `ProviderRepository`, and `SelfUpdateRepository` interfaces
 - **Infrastructure adapters**: `internal/infrastructure/repositories/` — updater implementations per ecosystem, plus `cmdrunner` (shared command execution), `gitlocal` (go-git operations for local and batch modes), and `selfupdate`
-- **Support utilities**: `internal/support/` — filesystem helpers, remote file checker bridging `langforge` with `gitforge`, and repo config loader for per-repo opt-out
+- **Support utilities**: `internal/support/` — filesystem helpers, remote file checker bridging `langforge` with `gitforge`, repo config loader for per-repo opt-out, and the shared changelog writer (see below)
 - **Registries**: `provider_registry.go` (abstract factory for Git providers) and `updater_registry.go` (holds all updater implementations)
 
 ### Key External Libraries
@@ -78,6 +78,32 @@ Auto-discovery searches `.`, `.config`, `configs`, `$HOME`, `$HOME/.config` for 
 **Repository exclusions:**
 - **Global**: `exclude_repos` in user config — right-anchored glob list matched against `<org>/<repo>` (or `<org>/<project>/<repo>` for ADO). Honored in batch mode and in local mode when a config file is loadable.
 - **Per-repo**: `.autoupdate.yaml` in the target repository's root with `skip: true` (and optional `reason`). Checked in both `autoupdate run` (fetched via provider API) and `autoupdate .` (read from disk).
+
+### Changelog Writing (Keep a Changelog and chlog)
+
+Every updater records its entries through `internal/support/changelog.go` — never call
+`entities.InsertChangelogEntry` or write `CHANGELOG.md` directly from an updater. The helper detects
+the target repository's format and picks the destination, so the two formats cannot drift apart:
+
+- `LocalChangelogUpdate(repoDir, entries)` — writes on disk (local mode).
+- `RemoteChangelogChanges(ctx, provider, repo, entries, fileChanges)` — appends `FileChange` values
+  for the provider API (batch mode), used by `terraform`, `dockerfile`, and `pipeline`.
+- `StageLocalChangelog` / `StageRemoteChangelog` — return a `StagedChangelog` (temp file plus
+  repository-relative destination) for the six ecosystems whose upgrade runs through a generated bash
+  script. The script gets `CHANGELOG_FILE` and `CHANGELOG_DEST` from `StagedChangelog.Env()` and
+  performs the copy with the shared snippet `support.ChangelogUpdateScript()`. Call
+  `StagedChangelog.Discard(repoDir)` when abandoning a run: a chlog fragment is a *new untracked*
+  file, so `git checkout -- .` would leave it behind (this is why the JavaScript cosmetic-lockfile
+  revert threads the staged value).
+
+chlog (`internal/support/chlog.go` + `internal/domain/entities/chlog.go`) is detected from a
+`.chlog.yaml`/`.chlog.yml` or a `.changes/unreleased/` directory. When detected, entries become one
+fragment file per entry (`<unixnano>-<hex>.yaml` with `kind`/`body`/`time`) and `CHANGELOG.md` is
+left untouched — editing it would recreate exactly the merge conflicts chlog exists to remove. The
+configured `changesDir`/`unreleasedDir`/`kinds` are honored, and paths are validated against escaping
+the repository root because `.chlog.yaml` is untrusted input from a repo autoupdate does not own. A
+broken or unreadable `.chlog.yaml` fails loudly rather than falling back to `CHANGELOG.md`. The
+per-ecosystem `changelogEntries(vCtx)` helper is all that remains ecosystem-specific.
 
 ### Stale Branch Cleanup
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A self-hosted Dependabot alternative that automatically discovers repositories, 
 - **Multi-Provider**: Supports GitHub, GitLab, and Azure DevOps as Git hosting providers
 - **API-Based Discovery**: Automatically discovers all repositories in an organization, group, or user account
 - **Extensible Updaters**: Plugin-based architecture for dependency ecosystems (Terraform modules, Go projects, and more coming)
-- **Changelog Integration**: Automatically updates `CHANGELOG.md` (Keep a Changelog format) when the target repository has one
+- **Changelog Integration**: Automatically updates `CHANGELOG.md` (Keep a Changelog format) when the target repository has one, or writes a [chlog](https://github.com/luizjhonata/chlog) fragment when the repository uses that format instead -- see [Changelog Formats](#changelog-formats)
 - **Cronjob-Ready**: Designed to run unattended on a schedule for daily dependency updates
 - **Dry Run Mode**: Preview all changes before creating any PRs
 - **Flexible Filtering**: Run against a specific provider, organization, or updater
@@ -137,6 +137,39 @@ honored in both `autoupdate run` (read via the provider API on the
 default branch) and `autoupdate .` (read directly from disk). Use it for
 forks you maintain by hand, frozen branches, or any project where
 automated PRs would create more work than they save.
+
+### Changelog Formats
+
+AutoUpdate records what it changed in the target repository's changelog, and
+picks the format from what that repository itself commits. Nothing has to be
+configured on the AutoUpdate side.
+
+**Keep a Changelog (default).** The entries are inserted into the
+`## [Unreleased]` / `### Changed` section of `CHANGELOG.md`. A repository
+without a `CHANGELOG.md` simply gets no changelog change.
+
+**chlog.** [chlog](https://github.com/luizjhonata/chlog) replaces the shared
+`CHANGELOG.md` with one small YAML file per change under `.changes/unreleased/`,
+which is what removes changelog merge conflicts between concurrent pull
+requests. Editing `[Unreleased]` in such a repository would put automated pull
+requests straight back into conflict, so AutoUpdate writes a fragment instead
+and leaves `CHANGELOG.md` alone:
+
+```yaml
+# .changes/unreleased/1748359200-a1b2.yaml
+kind: Changed
+body: changed the Go module dependencies to their latest versions
+time: 2026-07-29T14:30:00Z
+```
+
+A repository is treated as a chlog user when it commits a `.chlog.yaml` (or
+`.chlog.yml`), or when it merely carries a `.changes/unreleased/` directory --
+chlog works without a configuration file. When the file is present, its
+`changesDir`, `unreleasedDir` and `kinds` are honored, so a project that
+renamed its directories or its `Changed` label still gets valid fragments. The
+`chlog merge` step later compiles them into the changelog as usual.
+
+Both formats work in every ecosystem and in both local and batch mode.
 
 ### Token Resolution
 

--- a/internal/domain/entities/chlog.go
+++ b/internal/domain/entities/chlog.go
@@ -1,0 +1,298 @@
+package entities
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// chlog (https://github.com/luizjhonata/chlog) is a fragment-based changelog
+// tool: instead of editing a shared CHANGELOG.md, every change is written to
+// its own YAML file under .changes/unreleased/, which removes changelog merge
+// conflicts entirely. The tool later compiles those fragments into ordinary
+// Keep a Changelog sections.
+//
+// A chlog repository therefore keeps [Unreleased] permanently empty, and the
+// entry autoupdate would append there is exactly the kind of edit chlog exists
+// to avoid: two updaters running against the same repository would conflict on
+// the same lines. When chlog is detected, autoupdate emits a fragment instead.
+//
+// chlog is a command-only Go module (everything lives under internal/), so its
+// format is re-implemented here rather than imported.
+
+// chlog configuration file names, in the order chlog itself probes them.
+const (
+	ChlogConfigFile    = ".chlog.yaml"
+	ChlogAltConfigFile = ".chlog.yml"
+)
+
+// Defaults mirroring chlog's DefaultConfig(). They apply whenever a repository
+// uses chlog without committing a configuration file, which chlog supports.
+const (
+	DefaultChlogChangesDir    = ".changes"
+	DefaultChlogUnreleasedDir = "unreleased"
+	DefaultChlogChangelogPath = "CHANGELOG.md"
+)
+
+// ChlogUpdateKind is the fragment kind autoupdate files its entries under.
+// gitforge's InsertChangelogEntry writes into "### Changed", so using the same
+// bucket keeps the released notes identical whichever format a repository uses.
+const ChlogUpdateKind = "Changed"
+
+// chlogRandomSuffixBytes matches chlog's own fragment naming: a nanosecond
+// timestamp plus four hex characters, which keeps names unique even when
+// several fragments are written inside the same nanosecond.
+const chlogRandomSuffixBytes = 2
+
+var (
+	// ErrChlogPathEscapesRepo is returned when .chlog.yaml configures a path
+	// that would take autoupdate outside the repository it was pointed at.
+	ErrChlogPathEscapesRepo = errors.New("chlog path escapes the repository root")
+
+	// ErrChlogNoKinds is returned when .chlog.yaml declares an empty kind list,
+	// which chlog itself rejects as invalid.
+	ErrChlogNoKinds = errors.New("chlog kinds list must not be empty")
+)
+
+// ChlogKind is a single entry of the "kinds" list in .chlog.yaml. Only Label
+// matters here: autoupdate always files under the "Changed" kind, so chlog's
+// Auto mapping (which drives version bumps) is deliberately not applied.
+type ChlogKind struct {
+	Label string `yaml:"label"`
+	Auto  string `yaml:"auto,omitempty"`
+}
+
+// ChlogConfig is the subset of .chlog.yaml that autoupdate needs. The rendering
+// templates (versionFormat, kindFormat, changeFormat) are ignored, since
+// autoupdate never compiles fragments -- it only writes them.
+type ChlogConfig struct {
+	ChangesDir    string      `yaml:"changesDir"`
+	UnreleasedDir string      `yaml:"unreleasedDir"`
+	ChangelogPath string      `yaml:"changelogPath"`
+	Kinds         []ChlogKind `yaml:"kinds"`
+}
+
+// ChlogFragment is one pending change, as stored in
+// .changes/unreleased/<timestamp>-<random>.yaml.
+type ChlogFragment struct {
+	Kind string    `yaml:"kind"`
+	Body string    `yaml:"body"`
+	Time time.Time `yaml:"time"`
+}
+
+// DefaultChlogConfig returns chlog's own defaults.
+func DefaultChlogConfig() ChlogConfig {
+	return ChlogConfig{
+		ChangesDir:    DefaultChlogChangesDir,
+		UnreleasedDir: DefaultChlogUnreleasedDir,
+		ChangelogPath: DefaultChlogChangelogPath,
+		Kinds: []ChlogKind{
+			{Label: "Added", Auto: "minor"},
+			{Label: "Changed", Auto: "major"},
+			{Label: "Deprecated", Auto: "minor"},
+			{Label: "Removed", Auto: "major"},
+			{Label: "Fixed", Auto: "patch"},
+			{Label: "Security", Auto: "patch"},
+		},
+	}
+}
+
+// ParseChlogConfig decodes raw .chlog.yaml bytes, filling any unset field from
+// chlog's defaults. Empty input yields the defaults, matching chlog's behaviour
+// for a repository that uses the tool without committing a configuration file.
+//
+// Unknown keys are tolerated: autoupdate only reads a subset of the schema.
+func ParseChlogConfig(data []byte) (*ChlogConfig, error) {
+	config := DefaultChlogConfig()
+	if len(data) > 0 {
+		if err := yaml.Unmarshal(data, &config); err != nil {
+			return nil, fmt.Errorf("failed to parse %s: %w", ChlogConfigFile, err)
+		}
+	}
+
+	applyChlogDefaults(&config)
+	if err := validateChlogConfig(&config); err != nil {
+		return nil, err
+	}
+	return &config, nil
+}
+
+// applyChlogDefaults restores chlog's defaults for keys the file left out. An
+// explicitly empty value is treated as absent rather than as "the repository
+// root", which is what chlog does when it merges a file over its defaults.
+func applyChlogDefaults(config *ChlogConfig) {
+	if strings.TrimSpace(config.ChangesDir) == "" {
+		config.ChangesDir = DefaultChlogChangesDir
+	}
+	if strings.TrimSpace(config.UnreleasedDir) == "" {
+		config.UnreleasedDir = DefaultChlogUnreleasedDir
+	}
+	if strings.TrimSpace(config.ChangelogPath) == "" {
+		config.ChangelogPath = DefaultChlogChangelogPath
+	}
+	if len(config.Kinds) == 0 {
+		config.Kinds = DefaultChlogConfig().Kinds
+	}
+}
+
+// validateChlogConfig rejects configured paths that leave the repository root.
+//
+// .chlog.yaml is committed by the repository being updated, and in batch mode
+// autoupdate processes repositories it does not own, so these values are
+// untrusted input. They drive the path autoupdate writes fragments to -- both
+// on disk in local mode and through the provider API in batch mode -- so an
+// absolute or parent-escaping value would let a hostile configuration write
+// outside the repository.
+func validateChlogConfig(config *ChlogConfig) error {
+	if len(config.Kinds) == 0 {
+		return ErrChlogNoKinds
+	}
+
+	fields := []struct{ name, value string }{
+		{"changesDir", config.ChangesDir},
+		{"unreleasedDir", config.UnreleasedDir},
+		{"changelogPath", config.ChangelogPath},
+		// The directories are joined, so a pair that is individually harmless
+		// but escapes once combined has to be rejected too.
+		{"changesDir/unreleasedDir", path.Join(config.ChangesDir, config.UnreleasedDir)},
+	}
+
+	for _, field := range fields {
+		if !isPathInsideRepo(field.value) {
+			return fmt.Errorf("%w: %s %q must be relative to the repository root",
+				ErrChlogPathEscapesRepo, field.name, field.value)
+		}
+	}
+	return nil
+}
+
+// isPathInsideRepo reports whether a configured path stays within the
+// repository root. An absolute path (in either separator style, since a
+// configuration written on Windows can be read on Linux and vice versa), "..",
+// or anything reaching through ".." would address a file autoupdate was never
+// pointed at.
+func isPathInsideRepo(value string) bool {
+	if value == "" || path.IsAbs(value) || filepath.IsAbs(value) {
+		return false
+	}
+	// A Windows drive-relative path such as "C:changes" is absolute on Windows
+	// but not recognised as such by the Linux path packages.
+	if strings.Contains(value, ":") {
+		return false
+	}
+
+	clean := path.Clean(filepath.ToSlash(value))
+	return clean != ".." && !strings.HasPrefix(clean, "../")
+}
+
+// UnreleasedPath returns the repository-relative directory holding the pending
+// fragments, always with forward slashes so it can be used both as a provider
+// API path and, after conversion, as an on-disk path.
+func (c *ChlogConfig) UnreleasedPath() string {
+	return path.Join(filepath.ToSlash(c.ChangesDir), filepath.ToSlash(c.UnreleasedDir))
+}
+
+// KindLabel resolves the label a repository uses for the given kind. chlog
+// matches kinds case-insensitively and a repository may rename the default
+// labels, so the configured spelling is returned when one matches. A repository
+// that dropped the kind entirely still gets the canonical label: chlog renders
+// unknown kinds as their own trailing section rather than dropping them, which
+// keeps the entry visible instead of silently losing it.
+func (c *ChlogConfig) KindLabel(kind string) string {
+	for _, configured := range c.Kinds {
+		if strings.EqualFold(strings.TrimSpace(configured.Label), strings.TrimSpace(kind)) {
+			return configured.Label
+		}
+	}
+	return kind
+}
+
+// NewChlogFragments turns Keep a Changelog bullet lines into chlog fragments,
+// one file per entry, and returns them as file changes ready to be written to
+// disk or committed through a provider. The entries are the same strings that
+// would otherwise be inserted under [Unreleased] / ### Changed, so callers do
+// not need to know which format the repository uses.
+//
+// An entry that carries no text once its bullet marker is stripped is skipped:
+// an empty fragment would render as an empty bullet at release time.
+func (c *ChlogConfig) NewChlogFragments(entries []string, at time.Time) ([]FileChange, error) {
+	changes := make([]FileChange, 0, len(entries))
+
+	for _, entry := range entries {
+		body := StripBulletPrefix(entry)
+		if body == "" {
+			continue
+		}
+
+		content, err := renderChlogFragment(c.KindLabel(ChlogUpdateKind), body, at)
+		if err != nil {
+			return nil, err
+		}
+
+		name, err := newChlogFragmentName(at)
+		if err != nil {
+			return nil, err
+		}
+
+		changes = append(changes, FileChange{
+			Path:       path.Join(c.UnreleasedPath(), name),
+			Content:    content,
+			ChangeType: "add",
+		})
+	}
+
+	return changes, nil
+}
+
+// StripBulletPrefix removes the leading Markdown bullet marker from a changelog
+// entry. Fragment bodies are stored without one -- chlog adds it back through
+// changeFormat -- so keeping it would render as "- - text" after a release.
+func StripBulletPrefix(entry string) string {
+	trimmed := strings.TrimSpace(entry)
+	if after, found := strings.CutPrefix(trimmed, "-"); found {
+		return strings.TrimSpace(after)
+	}
+	return trimmed
+}
+
+// renderChlogFragment marshals one fragment into chlog's on-disk YAML shape.
+func renderChlogFragment(kind, body string, at time.Time) (string, error) {
+	data, err := yaml.Marshal(&ChlogFragment{
+		Kind: kind,
+		Body: body,
+		Time: at.UTC(),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to render the chlog fragment: %w", err)
+	}
+	return string(data), nil
+}
+
+// newChlogFragmentName builds a fragment file name in chlog's own format:
+// "<unix-nanoseconds>-<four hex characters>.yaml".
+func newChlogFragmentName(at time.Time) (string, error) {
+	suffix := make([]byte, chlogRandomSuffixBytes)
+	if _, err := rand.Read(suffix); err != nil {
+		return "", fmt.Errorf("failed to generate the chlog fragment name: %w", err)
+	}
+	return fmt.Sprintf("%d-%s.yaml", at.UnixNano(), hex.EncodeToString(suffix)), nil
+}
+
+// ChlogFragmentDiskPath converts a repository-relative fragment path into an
+// absolute path under repoDir, using the host separator.
+func ChlogFragmentDiskPath(repoDir, fragmentPath string) string {
+	return filepath.Join(repoDir, filepath.FromSlash(fragmentPath))
+}
+
+// ChlogFragmentDirMode is the permission applied to the fragment directory when
+// autoupdate has to create it. A directory needs the owner execute (search) bit,
+// so 0o700 -- not the 0o600 used for files -- is the least-privilege mode.
+const ChlogFragmentDirMode os.FileMode = 0o700

--- a/internal/domain/entities/chlog.go
+++ b/internal/domain/entities/chlog.go
@@ -110,11 +110,15 @@ func DefaultChlogConfig() ChlogConfig {
 // for a repository that uses the tool without committing a configuration file.
 //
 // Unknown keys are tolerated: autoupdate only reads a subset of the schema.
+//
+// The error deliberately does not name a file: the caller knows whether these
+// bytes came from .chlog.yaml, .chlog.yml, or a provider API, and wraps the
+// error with the path it actually read.
 func ParseChlogConfig(data []byte) (*ChlogConfig, error) {
 	config := DefaultChlogConfig()
 	if len(data) > 0 {
 		if err := yaml.Unmarshal(data, &config); err != nil {
-			return nil, fmt.Errorf("failed to parse %s: %w", ChlogConfigFile, err)
+			return nil, fmt.Errorf("failed to parse the chlog configuration: %w", err)
 		}
 	}
 
@@ -125,22 +129,34 @@ func ParseChlogConfig(data []byte) (*ChlogConfig, error) {
 	return &config, nil
 }
 
-// applyChlogDefaults restores chlog's defaults for keys the file left out. An
-// explicitly empty value is treated as absent rather than as "the repository
-// root", which is what chlog does when it merges a file over its defaults.
+// applyChlogDefaults restores chlog's defaults for keys the file left out and
+// normalizes the configured paths to forward slashes. An explicitly empty value
+// is treated as absent rather than as "the repository root", which is what chlog
+// does when it merges a file over its defaults.
 func applyChlogDefaults(config *ChlogConfig) {
-	if strings.TrimSpace(config.ChangesDir) == "" {
-		config.ChangesDir = DefaultChlogChangesDir
-	}
-	if strings.TrimSpace(config.UnreleasedDir) == "" {
-		config.UnreleasedDir = DefaultChlogUnreleasedDir
-	}
-	if strings.TrimSpace(config.ChangelogPath) == "" {
-		config.ChangelogPath = DefaultChlogChangelogPath
-	}
+	config.ChangesDir = normalizeChlogPath(config.ChangesDir, DefaultChlogChangesDir)
+	config.UnreleasedDir = normalizeChlogPath(config.UnreleasedDir, DefaultChlogUnreleasedDir)
+	config.ChangelogPath = normalizeChlogPath(config.ChangelogPath, DefaultChlogChangelogPath)
 	if len(config.Kinds) == 0 {
 		config.Kinds = DefaultChlogConfig().Kinds
 	}
+}
+
+// normalizeChlogPath returns the configured value in forward-slash form, or the
+// fallback when the file left the key out.
+//
+// The conversion is unconditional rather than [filepath.ToSlash], which only
+// rewrites the separator of the *running* platform and is therefore a no-op on
+// Linux. A configuration is committed once and read wherever autoupdate happens
+// to run, so a Windows-authored `docs\changes` has to mean the same directory on
+// both — and, more importantly, `..\..\etc` has to be recognised as an escape by
+// the validation below no matter which platform validates it.
+func normalizeChlogPath(value, fallback string) string {
+	normalized := strings.ReplaceAll(strings.TrimSpace(value), `\`, "/")
+	if normalized == "" {
+		return fallback
+	}
+	return normalized
 }
 
 // validateChlogConfig rejects configured paths that leave the repository root.
@@ -174,30 +190,38 @@ func validateChlogConfig(config *ChlogConfig) error {
 	return nil
 }
 
-// isPathInsideRepo reports whether a configured path stays within the
-// repository root. An absolute path (in either separator style, since a
-// configuration written on Windows can be read on Linux and vice versa), "..",
-// or anything reaching through ".." would address a file autoupdate was never
-// pointed at.
+// isPathInsideRepo reports whether a configured path stays within the repository
+// root. An absolute path, "..", or anything reaching through ".." would address
+// a file autoupdate was never pointed at.
+//
+// The value has already been normalized to forward slashes by
+// [normalizeChlogPath], which is what makes this decision independent of the
+// platform doing the validating: `..\..\etc` reaches the ".." check as
+// `../../etc` on Linux too, and `\tmp\evil` arrives as the absolute `/tmp/evil`
+// rather than as a single oddly-named element. Both are rejected either way.
 func isPathInsideRepo(value string) bool {
-	if value == "" || path.IsAbs(value) || filepath.IsAbs(value) {
+	if value == "" {
 		return false
 	}
-	// A Windows drive-relative path such as "C:changes" is absolute on Windows
-	// but not recognised as such by the Linux path packages.
+	// A Windows drive-relative path such as "C:changes", and the "C:/changes"
+	// form, are absolute on Windows but not recognised as such by [path].
 	if strings.Contains(value, ":") {
 		return false
 	}
 
-	clean := path.Clean(filepath.ToSlash(value))
+	clean := path.Clean(value)
+	if path.IsAbs(clean) || filepath.IsAbs(clean) {
+		return false
+	}
 	return clean != ".." && !strings.HasPrefix(clean, "../")
 }
 
 // UnreleasedPath returns the repository-relative directory holding the pending
-// fragments, always with forward slashes so it can be used both as a provider
-// API path and, after conversion, as an on-disk path.
+// fragments. Parsing normalized both components to forward slashes, so the
+// result can be used as a provider API path directly and, after conversion by
+// [ChlogFragmentDiskPath], as an on-disk path.
 func (c *ChlogConfig) UnreleasedPath() string {
-	return path.Join(filepath.ToSlash(c.ChangesDir), filepath.ToSlash(c.UnreleasedDir))
+	return path.Join(c.ChangesDir, c.UnreleasedDir)
 }
 
 // KindLabel resolves the label a repository uses for the given kind. chlog

--- a/internal/domain/entities/chlog_test.go
+++ b/internal/domain/entities/chlog_test.go
@@ -99,6 +99,46 @@ func TestParseChlogConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("should reject a backslash path that escapes the repository root", func(t *testing.T) {
+		t.Parallel()
+
+		// A configuration is committed once and read wherever autoupdate runs, so
+		// these have to be rejected on Linux too even though only Windows resolves
+		// the separator. `filepath.ToSlash` is a no-op on Linux, so nothing but an
+		// unconditional normalization catches them.
+		// given
+		escaping := []string{
+			`changesDir: ..\..\etc` + "\n",
+			`unreleasedDir: ..\..\..\tmp` + "\n",
+			`changelogPath: \tmp\evil` + "\n",
+			`changesDir: \\server\share` + "\n",
+			`changesDir: .changes` + "\n" + `unreleasedDir: ..\..` + "\n",
+		}
+
+		for _, data := range escaping {
+			// when
+			config, err := entities.ParseChlogConfig([]byte(data))
+
+			// then
+			require.ErrorIs(t, err, entities.ErrChlogPathEscapesRepo, data)
+			assert.Nil(t, config)
+		}
+	})
+
+	t.Run("should read a backslash directory as the same path a slash one names", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		data := []byte(`changesDir: docs\changes` + "\n" + `unreleasedDir: pending` + "\n")
+
+		// when
+		config, err := entities.ParseChlogConfig(data)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "docs/changes/pending", config.UnreleasedPath())
+	})
+
 	t.Run("should return an error when the file is not valid YAML", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/domain/entities/chlog_test.go
+++ b/internal/domain/entities/chlog_test.go
@@ -1,0 +1,279 @@
+//go:build unit
+
+package entities_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/rios0rios0/autoupdate/internal/domain/entities"
+)
+
+func TestParseChlogConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return chlog defaults when the file is empty", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		var data []byte
+
+		// when
+		config, err := entities.ParseChlogConfig(data)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, ".changes", config.ChangesDir)
+		assert.Equal(t, "unreleased", config.UnreleasedDir)
+		assert.Equal(t, "CHANGELOG.md", config.ChangelogPath)
+		assert.Len(t, config.Kinds, 6)
+	})
+
+	t.Run("should honour the directories declared by the file", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		data := []byte("changesDir: docs/changes\nunreleasedDir: pending\n")
+
+		// when
+		config, err := entities.ParseChlogConfig(data)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "docs/changes/pending", config.UnreleasedPath())
+	})
+
+	t.Run("should fill the omitted keys from the defaults", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		data := []byte("changelogPath: docs/CHANGELOG.md\n")
+
+		// when
+		config, err := entities.ParseChlogConfig(data)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "docs/CHANGELOG.md", config.ChangelogPath)
+		assert.Equal(t, ".changes/unreleased", config.UnreleasedPath())
+	})
+
+	t.Run("should ignore the keys autoupdate does not read", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		data := []byte("versionFormat: '## {{.Version}}'\nchangeFormat: '* {{.Body}}'\n")
+
+		// when
+		config, err := entities.ParseChlogConfig(data)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, ".changes/unreleased", config.UnreleasedPath())
+	})
+
+	t.Run("should reject a directory that escapes the repository root", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		escaping := []string{
+			"changesDir: ../../etc\n",
+			"changesDir: /etc\n",
+			"unreleasedDir: ../../../tmp\n",
+			"changelogPath: /tmp/CHANGELOG.md\n",
+			"changesDir: .changes\nunreleasedDir: ../../..\n",
+		}
+
+		for _, data := range escaping {
+			// when
+			config, err := entities.ParseChlogConfig([]byte(data))
+
+			// then
+			require.ErrorIs(t, err, entities.ErrChlogPathEscapesRepo, data)
+			assert.Nil(t, config)
+		}
+	})
+
+	t.Run("should return an error when the file is not valid YAML", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		data := []byte("changesDir: [unterminated\n")
+
+		// when
+		config, err := entities.ParseChlogConfig(data)
+
+		// then
+		require.Error(t, err)
+		assert.Nil(t, config)
+	})
+}
+
+func TestChlogConfigKindLabel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return the spelling the repository configured", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		config, err := entities.ParseChlogConfig([]byte("kinds:\n  - label: CHANGED\n  - label: Fixed\n"))
+		require.NoError(t, err)
+
+		// when
+		label := config.KindLabel("Changed")
+
+		// then
+		assert.Equal(t, "CHANGED", label)
+	})
+
+	t.Run("should fall back to the canonical label when the kind is not configured", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		config, err := entities.ParseChlogConfig([]byte("kinds:\n  - label: Fixed\n"))
+		require.NoError(t, err)
+
+		// when
+		label := config.KindLabel("Changed")
+
+		// then
+		assert.Equal(t, "Changed", label)
+	})
+}
+
+func TestNewChlogFragments(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, time.July, 29, 10, 30, 0, 0, time.UTC)
+
+	t.Run("should render one fragment per entry under the unreleased directory", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		config := entities.DefaultChlogConfig()
+		entries := []string{
+			"- changed the Go module dependencies to their latest versions",
+			"- changed the Docker base image `alpine` from `3.19` to `3.20`",
+		}
+
+		// when
+		fragments, err := config.NewChlogFragments(entries, at)
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, fragments, 2)
+		for _, fragment := range fragments {
+			assert.True(t, strings.HasPrefix(fragment.Path, ".changes/unreleased/"), fragment.Path)
+			assert.True(t, strings.HasSuffix(fragment.Path, ".yaml"), fragment.Path)
+			assert.Equal(t, "add", fragment.ChangeType)
+		}
+		assert.NotEqual(t, fragments[0].Path, fragments[1].Path)
+	})
+
+	t.Run("should store the entry as a chlog fragment without its bullet marker", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		config := entities.DefaultChlogConfig()
+		entries := []string{"- changed the Go module dependencies to their latest versions"}
+
+		// when
+		fragments, err := config.NewChlogFragments(entries, at)
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, fragments, 1)
+
+		var fragment entities.ChlogFragment
+		require.NoError(t, yaml.Unmarshal([]byte(fragments[0].Content), &fragment))
+		assert.Equal(t, "Changed", fragment.Kind)
+		assert.Equal(t, "changed the Go module dependencies to their latest versions", fragment.Body)
+		assert.Equal(t, at, fragment.Time.UTC())
+	})
+
+	t.Run("should use the kind label the repository configured", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		config, err := entities.ParseChlogConfig([]byte("kinds:\n  - label: Updated\n  - label: changed\n"))
+		require.NoError(t, err)
+
+		// when
+		fragments, err := config.NewChlogFragments([]string{"- changed a dependency"}, at)
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, fragments, 1)
+
+		var fragment entities.ChlogFragment
+		require.NoError(t, yaml.Unmarshal([]byte(fragments[0].Content), &fragment))
+		assert.Equal(t, "changed", fragment.Kind)
+	})
+
+	t.Run("should skip an entry that carries no text", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		config := entities.DefaultChlogConfig()
+		entries := []string{"-", "   ", "- changed a dependency"}
+
+		// when
+		fragments, err := config.NewChlogFragments(entries, at)
+
+		// then
+		require.NoError(t, err)
+		assert.Len(t, fragments, 1)
+	})
+
+	t.Run("should write into the directory the configuration declares", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		config, err := entities.ParseChlogConfig(
+			[]byte("changesDir: docs/changes\nunreleasedDir: pending\n"))
+		require.NoError(t, err)
+
+		// when
+		fragments, err := config.NewChlogFragments([]string{"- changed a dependency"}, at)
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, fragments, 1)
+		assert.True(t, strings.HasPrefix(fragments[0].Path, "docs/changes/pending/"), fragments[0].Path)
+	})
+}
+
+func TestStripBulletPrefix(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should remove the leading bullet marker", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		entry := "- changed a dependency"
+
+		// when
+		body := entities.StripBulletPrefix(entry)
+
+		// then
+		assert.Equal(t, "changed a dependency", body)
+	})
+
+	t.Run("should return the text unchanged when there is no bullet marker", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		entry := "  changed a dependency  "
+
+		// when
+		body := entities.StripBulletPrefix(entry)
+
+		// then
+		assert.Equal(t, "changed a dependency", body)
+	})
+}

--- a/internal/infrastructure/repositories/csharp/csharp_updater_repository.go
+++ b/internal/infrastructure/repositories/csharp/csharp_updater_repository.go
@@ -156,10 +156,8 @@ func cloneAndUpgrade(
 	repo entities.Repository,
 	vCtx *versionContext,
 ) (*upgradeResult, error) {
-	changelogFile := prepareChangelog(ctx, provider, repo, vCtx)
-	if changelogFile != "" {
-		defer os.Remove(changelogFile)
-	}
+	changelog := support.StageRemoteChangelog(ctx, provider, repo, changelogEntries(vCtx))
+	defer changelog.Remove()
 
 	cloneURL := provider.CloneURL(repo)
 	defaultBranch := strings.TrimPrefix(repo.DefaultBranch, "refs/heads/")
@@ -176,7 +174,7 @@ func cloneAndUpgrade(
 		DotnetVersion: vCtx.LatestVersion,
 		AuthToken:     provider.AuthToken(),
 		ProviderName:  provider.Name(),
-		ChangelogFile: changelogFile,
+		Changelog:     changelog,
 		DotnetBinary:  dotnetBinary,
 	})
 	if err != nil {
@@ -282,7 +280,7 @@ func (u *UpdaterRepository) ApplyUpdates(
 		return nil, repositories.ErrNoUpdatesNeeded
 	}
 
-	// Update CHANGELOG locally
+	// Record the upgrade in the repository's changelog.
 	var entry string
 	if dotnetVersionUpdated {
 		entry = fmt.Sprintf(
@@ -341,8 +339,10 @@ type upgradeParams struct {
 	DotnetVersion string
 	AuthToken     string
 	ProviderName  string
-	ChangelogFile string
-	DotnetBinary  string
+	// Changelog is the staged changelog payload the script copies into
+	// the clone; an empty value leaves the repository's changelog untouched.
+	Changelog    support.StagedChangelog
+	DotnetBinary string
 }
 
 type upgradeResult struct {
@@ -440,55 +440,17 @@ func resolveLocalVersionContext(ctx context.Context, repoDir string) *versionCon
 	}
 }
 
-// prepareChangelog reads the target repo's CHANGELOG.md (if it exists),
-// inserts an entry describing the .NET upgrade, and writes the modified
-// content to a temp file.
-func prepareChangelog(
-	ctx context.Context,
-	provider repositories.ProviderRepository,
-	repo entities.Repository,
-	vCtx *versionContext,
-) string {
-	if !provider.HasFile(ctx, repo, "CHANGELOG.md") {
-		return ""
-	}
-
-	content, err := provider.GetFileContent(ctx, repo, "CHANGELOG.md")
-	if err != nil {
-		logger.Warnf("[csharp] Failed to read CHANGELOG.md: %v", err)
-		return ""
-	}
-
-	var entry string
+// changelogEntries renders the Keep a Changelog bullet describing the
+// upgrade. The staging helpers turn it into a chlog fragment when the
+// target repository uses that format instead.
+func changelogEntries(vCtx *versionContext) []string {
 	if vCtx.NeedsVersionUpgrade {
-		entry = fmt.Sprintf(
+		return []string{fmt.Sprintf(
 			"- changed the .NET SDK version to `%s` and updated all NuGet dependencies",
 			vCtx.LatestVersion,
-		)
-	} else {
-		entry = dotnetChangelogEntryDeps
+		)}
 	}
-
-	modified := entities.InsertChangelogEntry(content, []string{entry})
-	if modified == content {
-		return ""
-	}
-
-	tmpFile, writeErr := os.CreateTemp("", "autoupdate-changelog-*.md")
-	if writeErr != nil {
-		logger.Warnf("[csharp] Failed to create temp changelog file: %v", writeErr)
-		return ""
-	}
-
-	if _, writeErr = tmpFile.WriteString(modified); writeErr != nil {
-		_ = tmpFile.Close()
-		_ = os.Remove(tmpFile.Name())
-		logger.Warnf("[csharp] Failed to write temp changelog: %v", writeErr)
-		return ""
-	}
-	_ = tmpFile.Close()
-
-	return tmpFile.Name()
+	return []string{dotnetChangelogEntryDeps}
 }
 
 // --- clone + upgrade ---
@@ -571,8 +533,9 @@ func buildUpgradeScript(
 	// Update Dockerfile .NET image tags
 	writeDockerfileUpdate(&sb)
 
-	// Overwrite CHANGELOG.md with the pre-generated content (if provided)
-	writeChangelogUpdate(&sb)
+	// Copy in the staged changelog: an edited CHANGELOG.md, or a chlog
+	// fragment when the target repository uses that format.
+	sb.WriteString(support.ChangelogUpdateScript())
 
 	// Check for changes and commit/push
 	writeCommitAndPush(&sb)
@@ -715,18 +678,6 @@ func writeDockerfileUpdate(sb *strings.Builder) {
 	sb.WriteString("fi\n\n")
 }
 
-func writeChangelogUpdate(sb *strings.Builder) {
-	sb.WriteString("# Update CHANGELOG.md only if the upgrade produced actual changes.\n")
-	sb.WriteString("if [ -n \"${CHANGELOG_FILE:-}\" ] && [ -f \"$CHANGELOG_FILE\" ]; then\n")
-	sb.WriteString("    if [ -n \"$(git status --porcelain)\" ]; then\n")
-	sb.WriteString("        echo \"Updating CHANGELOG.md...\"\n")
-	sb.WriteString("        cp \"$CHANGELOG_FILE\" CHANGELOG.md\n")
-	sb.WriteString("    else\n")
-	sb.WriteString("        echo \"No dependency changes detected, skipping CHANGELOG update.\"\n")
-	sb.WriteString("    fi\n")
-	sb.WriteString("fi\n\n")
-}
-
 func writeCommitAndPush(sb *strings.Builder) {
 	sb.WriteString("if [ -n \"$(git status --porcelain)\" ]; then\n")
 	sb.WriteString("    echo \"Changes detected, committing and pushing...\"\n")
@@ -759,9 +710,7 @@ func buildEnv(params upgradeParams, repoDir string) []string {
 	if params.DotnetVersion != "" {
 		env = append(env, "DOTNET_VERSION="+params.DotnetVersion)
 	}
-	if params.ChangelogFile != "" {
-		env = append(env, "CHANGELOG_FILE="+params.ChangelogFile)
-	}
+	env = append(env, params.Changelog.Env()...)
 	return env
 }
 

--- a/internal/infrastructure/repositories/csharp/export_test.go
+++ b/internal/infrastructure/repositories/csharp/export_test.go
@@ -77,14 +77,9 @@ func BuildEnv(params UpgradeParamsExported, repoDir string) []string {
 	return buildEnv(params, repoDir)
 }
 
-// PrepareChangelog is exported for testing.
-func PrepareChangelog(
-	ctx context.Context,
-	provider repositories.ProviderRepository,
-	repo entities.Repository,
-	vCtx *VersionContext,
-) string {
-	return prepareChangelog(ctx, provider, repo, vCtx)
+// ChangelogEntries is exported for testing.
+func ChangelogEntries(vCtx *VersionContext) []string {
+	return changelogEntries(vCtx)
 }
 
 // LogDryRun is exported for testing.
@@ -107,11 +102,6 @@ func OpenPullRequest(
 // WriteDockerfileUpdate is exported for testing.
 func WriteDockerfileUpdate(sb *strings.Builder) {
 	writeDockerfileUpdate(sb)
-}
-
-// WriteChangelogUpdate is exported for testing.
-func WriteChangelogUpdate(sb *strings.Builder) {
-	writeChangelogUpdate(sb)
 }
 
 // WriteCommitAndPush is exported for testing.

--- a/internal/infrastructure/repositories/dockerfile/dockerfile_updater_repository.go
+++ b/internal/infrastructure/repositories/dockerfile/dockerfile_updater_repository.go
@@ -139,14 +139,7 @@ func (u *UpdaterRepository) ApplyUpdates(
 		return nil, err
 	}
 
-	entries := make([]string, 0, len(upgrades))
-	for _, up := range upgrades {
-		entries = append(entries, fmt.Sprintf(
-			"- changed the Docker base image `%s` from `%s` to `%s`",
-			up.parsed.FullName(), up.dep.CurrentVer, up.newTag,
-		))
-	}
-	support.LocalChangelogUpdate(repoDir, entries)
+	support.LocalChangelogUpdate(repoDir, changelogEntries(upgrades))
 
 	return &repositories.LocalUpdateResult{
 		BranchName:    generateBranchName(upgrades),
@@ -499,6 +492,10 @@ func generatePRDescription(tasks []upgradeTask) string {
 	return sb.String()
 }
 
+// appendChangelogEntry records the base image upgrades in the target repo's
+// changelog and appends the resulting file to the change set. The format --
+// Keep a Changelog or chlog fragments -- is decided by the shared helper from
+// what the repository itself commits.
 func appendChangelogEntry(
 	ctx context.Context,
 	provider repositories.ProviderRepository,
@@ -506,16 +503,12 @@ func appendChangelogEntry(
 	upgrades []upgradeTask,
 	fileChanges []entities.FileChange,
 ) []entities.FileChange {
-	if !provider.HasFile(ctx, repo, "CHANGELOG.md") {
-		return fileChanges
-	}
+	return support.RemoteChangelogChanges(
+		ctx, provider, repo, changelogEntries(upgrades), fileChanges)
+}
 
-	content, err := provider.GetFileContent(ctx, repo, "CHANGELOG.md")
-	if err != nil {
-		logger.Warnf("[dockerfile] Failed to read CHANGELOG.md: %v", err)
-		return fileChanges
-	}
-
+// changelogEntries renders one Keep a Changelog bullet per upgrade.
+func changelogEntries(upgrades []upgradeTask) []string {
 	entries := make([]string, 0, len(upgrades))
 	for _, up := range upgrades {
 		entries = append(entries, fmt.Sprintf(
@@ -523,15 +516,5 @@ func appendChangelogEntry(
 			up.parsed.FullName(), up.dep.CurrentVer, up.newTag,
 		))
 	}
-
-	modified := entities.InsertChangelogEntry(content, entries)
-	if modified == content {
-		return fileChanges
-	}
-
-	return append(fileChanges, entities.FileChange{
-		Path:       "CHANGELOG.md",
-		Content:    modified,
-		ChangeType: "edit",
-	})
+	return entries
 }

--- a/internal/infrastructure/repositories/dockerfile/export_test.go
+++ b/internal/infrastructure/repositories/dockerfile/export_test.go
@@ -210,4 +210,3 @@ func splitNamespace(imageName string) [2]string {
 	}
 	return [2]string{"", imageName}
 }
-

--- a/internal/infrastructure/repositories/gitlocal/batch_git_test.go
+++ b/internal/infrastructure/repositories/gitlocal/batch_git_test.go
@@ -265,7 +265,6 @@ func TestBatchHasChanges(t *testing.T) {
 	})
 }
 
-
 func TestSwitchToDefault(t *testing.T) {
 	t.Parallel()
 

--- a/internal/infrastructure/repositories/golang/export_test.go
+++ b/internal/infrastructure/repositories/golang/export_test.go
@@ -98,16 +98,6 @@ type UpgradeParams = upgradeParams
 // UpgradeResult is exported for testing.
 type UpgradeResult = upgradeResult
 
-// PrepareChangelog is exported for testing.
-func PrepareChangelog(
-	ctx context.Context,
-	provider repositories.ProviderRepository,
-	repo entities.Repository,
-	vCtx *versionContext,
-) string {
-	return prepareChangelog(ctx, provider, repo, vCtx)
-}
-
 // NewUpdaterRepositoryForTest creates an updater with injected dependencies.
 func NewUpdaterRepositoryForTest(vf VersionFetcher, runner ...cmdrunner.Runner) *UpdaterRepository {
 	r := cmdrunner.Runner(cmdrunner.NewDefaultRunner())
@@ -175,11 +165,6 @@ func BuildLocalEnvFull(params localUpgradeParams, goBinary string) []string {
 	return buildLocalEnv(params, goBinary)
 }
 
-// PrepareLocalChangelog is exported for testing.
-func PrepareLocalChangelog(repoDir string, vCtx *versionContext) string {
-	return prepareLocalChangelog(repoDir, vCtx)
-}
-
 // SetLocalCmdRunner overrides the package-level local command runner for testing.
 func SetLocalCmdRunner(r cmdrunner.Runner) func() {
 	old := localCmdRunner
@@ -225,4 +210,9 @@ func UpdateDockerfileGolangTags(
 	listTags func(ctx context.Context) ([]string, error),
 ) (bool, error) {
 	return updateDockerfileGolangTags(ctx, repoDir, goVersion, listTags)
+}
+
+// ChangelogEntries is exported for testing.
+func ChangelogEntries(vCtx *versionContext) []string {
+	return changelogEntries(vCtx)
 }

--- a/internal/infrastructure/repositories/golang/golang_updater_repository.go
+++ b/internal/infrastructure/repositories/golang/golang_updater_repository.go
@@ -243,7 +243,7 @@ func (u *UpdaterRepository) ApplyUpdates(
 	}
 	logger.Infof("[golang] Filesystem changes detected, proceeding with commit")
 
-	// Update CHANGELOG locally
+	// Record the upgrade in the repository's changelog.
 	var entry string
 	if goVersionUpdated {
 		entry = fmt.Sprintf(
@@ -358,10 +358,8 @@ func cloneAndUpgrade(
 	vCtx *versionContext,
 ) (*upgradeResult, bool, error) {
 	hasConfigSH := provider.HasFile(ctx, repo, "config.sh")
-	changelogFile := prepareChangelog(ctx, provider, repo, vCtx)
-	if changelogFile != "" {
-		defer os.Remove(changelogFile)
-	}
+	changelog := support.StageRemoteChangelog(ctx, provider, repo, changelogEntries(vCtx))
+	defer changelog.Remove()
 
 	cloneURL := provider.CloneURL(repo)
 	defaultBranch := strings.TrimPrefix(repo.DefaultBranch, "refs/heads/")
@@ -374,7 +372,7 @@ func cloneAndUpgrade(
 		AuthToken:     provider.AuthToken(),
 		HasConfigSH:   hasConfigSH,
 		ProviderName:  provider.Name(),
-		ChangelogFile: changelogFile,
+		Changelog:     changelog,
 	})
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to upgrade: %w", err)
@@ -481,56 +479,17 @@ func resolveVersionContext(
 	}
 }
 
-// prepareChangelog reads the target repo's CHANGELOG.md (if it exists),
-// inserts an entry describing the Go upgrade, and writes the modified
-// content to a temp file.  Returns the temp file path, or "" if no
-// changelog is present or reading/writing fails.
-func prepareChangelog(
-	ctx context.Context,
-	provider repositories.ProviderRepository,
-	repo entities.Repository,
-	vCtx *versionContext,
-) string {
-	if !provider.HasFile(ctx, repo, "CHANGELOG.md") {
-		return ""
-	}
-
-	content, err := provider.GetFileContent(ctx, repo, "CHANGELOG.md")
-	if err != nil {
-		logger.Warnf("[golang] Failed to read CHANGELOG.md: %v", err)
-		return ""
-	}
-
-	var entry string
+// changelogEntries renders the Keep a Changelog bullet describing the upgrade.
+// The staging helpers turn it into a chlog fragment when the target repository
+// uses that format instead.
+func changelogEntries(vCtx *versionContext) []string {
 	if vCtx.NeedsVersionUpgrade {
-		entry = fmt.Sprintf(
+		return []string{fmt.Sprintf(
 			"- changed the Go version to `%s` and updated all module dependencies",
 			vCtx.LatestVersion,
-		)
-	} else {
-		entry = goChangelogEntryDeps
+		)}
 	}
-
-	modified := entities.InsertChangelogEntry(content, []string{entry})
-	if modified == content {
-		return ""
-	}
-
-	tmpFile, writeErr := os.CreateTemp("", "autoupdate-changelog-*.md")
-	if writeErr != nil {
-		logger.Warnf("[golang] Failed to create temp changelog file: %v", writeErr)
-		return ""
-	}
-
-	if _, writeErr = tmpFile.WriteString(modified); writeErr != nil {
-		_ = tmpFile.Close()
-		_ = os.Remove(tmpFile.Name())
-		logger.Warnf("[golang] Failed to write temp changelog: %v", writeErr)
-		return ""
-	}
-	_ = tmpFile.Close()
-
-	return tmpFile.Name()
+	return []string{goChangelogEntryDeps}
 }
 
 // --- internal types ---
@@ -543,7 +502,9 @@ type upgradeParams struct {
 	AuthToken     string
 	HasConfigSH   bool
 	ProviderName  string
-	ChangelogFile string // path to a temp file with updated CHANGELOG.md content (empty = no changelog)
+	// Changelog is the staged changelog payload the script copies into the
+	// clone; an empty value leaves the repository's changelog untouched.
+	Changelog support.StagedChangelog
 }
 
 type upgradeResult struct {
@@ -688,8 +649,9 @@ func buildUpgradeScript(
 	// implements LocalUpdater, so ApplyUpdates handles live runs and performs
 	// the registry-verified Dockerfile rewrite in Go).
 
-	// Overwrite CHANGELOG.md with the pre-generated content (if provided)
-	writeChangelogUpdate(&sb)
+	// Copy in the staged changelog: an edited CHANGELOG.md, or a chlog
+	// fragment when the target repository uses that format.
+	sb.WriteString(support.ChangelogUpdateScript())
 
 	// Check for changes and commit/push
 	writeCommitAndPush(&sb)
@@ -843,19 +805,6 @@ func writeGoModuleUpgradeCommands(sb *strings.Builder) {
 	sb.WriteString("    fi\n\n")
 }
 
-func writeChangelogUpdate(sb *strings.Builder) {
-	sb.WriteString("# Update CHANGELOG.md only if the Go upgrade produced actual changes.\n")
-	sb.WriteString("# This prevents creating empty PRs that only touch the changelog.\n")
-	sb.WriteString("if [ -n \"${CHANGELOG_FILE:-}\" ] && [ -f \"$CHANGELOG_FILE\" ]; then\n")
-	sb.WriteString("    if [ -n \"$(git status --porcelain)\" ]; then\n")
-	sb.WriteString("        echo \"Updating CHANGELOG.md...\"\n")
-	sb.WriteString("        cp \"$CHANGELOG_FILE\" CHANGELOG.md\n")
-	sb.WriteString("    else\n")
-	sb.WriteString("        echo \"No dependency changes detected, skipping CHANGELOG update.\"\n")
-	sb.WriteString("    fi\n")
-	sb.WriteString("fi\n\n")
-}
-
 func writeCommitAndPush(sb *strings.Builder) {
 	sb.WriteString("if [ -n \"$(git status --porcelain)\" ]; then\n")
 	sb.WriteString("    echo \"Changes detected, committing and pushing...\"\n")
@@ -891,9 +840,7 @@ func buildEnv(params upgradeParams, repoDir, goBinary string) []string {
 		"GO_BINARY="+goBinary,
 		"DEFAULT_BRANCH="+params.DefaultBranch,
 	)
-	if params.ChangelogFile != "" {
-		env = append(env, "CHANGELOG_FILE="+params.ChangelogFile)
-	}
+	env = append(env, params.Changelog.Env()...)
 	return env
 }
 

--- a/internal/infrastructure/repositories/golang/golang_updater_repository_test.go
+++ b/internal/infrastructure/repositories/golang/golang_updater_repository_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/rios0rios0/autoupdate/internal/domain/entities"
 	goUpdater "github.com/rios0rios0/autoupdate/internal/infrastructure/repositories/golang"
+	"github.com/rios0rios0/autoupdate/internal/support"
 	"github.com/rios0rios0/autoupdate/test/infrastructure/repositorydoubles"
 )
 
@@ -441,8 +442,8 @@ func TestBuildUpgradeScript(t *testing.T) {
 
 		// given
 		params := goUpdater.UpgradeParams{
-			ProviderName:  "github",
-			ChangelogFile: "/tmp/changelog.md",
+			ProviderName: "github",
+			Changelog:    support.StagedChangelog{TempPath: "/tmp/changelog.md", RepoPath: "CHANGELOG.md"},
 		}
 
 		// when
@@ -591,46 +592,35 @@ func TestOpenPullRequest(t *testing.T) {
 	})
 }
 
-func TestPrepareChangelog(t *testing.T) {
+func TestChangelogEntries(t *testing.T) {
 	t.Parallel()
 
-	t.Run("should return temp file path when CHANGELOG.md exists", func(t *testing.T) {
+	t.Run("should describe the version upgrade when one is needed", func(t *testing.T) {
 		t.Parallel()
 
 		// given
-		changelog := "# Changelog\n\n## [Unreleased]\n\n## [1.0.0] - 2026-01-01\n"
-		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
-			WithExistingFiles(map[string]bool{"CHANGELOG.md": true}).
-			WithFileContents(map[string]string{"CHANGELOG.md": changelog}).
-			BuildSpy()
-		repo := entities.Repository{Organization: "org", Name: "repo"}
 		vCtx := &goUpdater.VersionContext{LatestVersion: "1.25.7", NeedsVersionUpgrade: true}
 
 		// when
-		result := goUpdater.PrepareChangelog(t.Context(), provider, repo, vCtx)
+		entries := goUpdater.ChangelogEntries(vCtx)
 
 		// then
-		assert.NotEmpty(t, result)
-		if result != "" {
-			defer os.Remove(result)
-		}
+		assert.Equal(t, []string{
+			"- changed the Go version to `1.25.7` and updated all module dependencies",
+		}, entries)
 	})
 
-	t.Run("should return empty string when no CHANGELOG.md", func(t *testing.T) {
+	t.Run("should describe only the dependencies when no version upgrade is needed", func(t *testing.T) {
 		t.Parallel()
 
 		// given
-		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
-			WithExistingFiles(map[string]bool{}).
-			BuildSpy()
-		repo := entities.Repository{Organization: "org", Name: "repo"}
-		vCtx := &goUpdater.VersionContext{LatestVersion: "1.25.7", NeedsVersionUpgrade: true}
+		vCtx := &goUpdater.VersionContext{LatestVersion: "1.25.7", NeedsVersionUpgrade: false}
 
 		// when
-		result := goUpdater.PrepareChangelog(t.Context(), provider, repo, vCtx)
+		entries := goUpdater.ChangelogEntries(vCtx)
 
 		// then
-		assert.Empty(t, result)
+		assert.Equal(t, []string{"- changed the Go module dependencies to their latest versions"}, entries)
 	})
 }
 
@@ -793,42 +783,5 @@ func TestBuildLocalEnvFull(t *testing.T) {
 			}
 		}
 		assert.True(t, found)
-	})
-}
-
-func TestPrepareLocalChangelogGo(t *testing.T) {
-	t.Parallel()
-
-	t.Run("should return temp file when CHANGELOG.md exists", func(t *testing.T) {
-		t.Parallel()
-
-		// given
-		root := t.TempDir()
-		changelog := "# Changelog\n\n## [Unreleased]\n\n## [1.0.0] - 2026-01-01\n"
-		require.NoError(t, os.WriteFile(filepath.Join(root, "CHANGELOG.md"), []byte(changelog), 0o600))
-		vCtx := &goUpdater.VersionContext{LatestVersion: "1.25.7", NeedsVersionUpgrade: true}
-
-		// when
-		result := goUpdater.PrepareLocalChangelog(root, vCtx)
-
-		// then
-		assert.NotEmpty(t, result)
-		if result != "" {
-			defer os.Remove(result)
-		}
-	})
-
-	t.Run("should return empty when no CHANGELOG.md", func(t *testing.T) {
-		t.Parallel()
-
-		// given
-		root := t.TempDir()
-		vCtx := &goUpdater.VersionContext{LatestVersion: "1.25.7", NeedsVersionUpgrade: true}
-
-		// when
-		result := goUpdater.PrepareLocalChangelog(root, vCtx)
-
-		// then
-		assert.Empty(t, result)
 	})
 }

--- a/internal/infrastructure/repositories/golang/local.go
+++ b/internal/infrastructure/repositories/golang/local.go
@@ -10,9 +10,9 @@ import (
 
 	logger "github.com/sirupsen/logrus"
 
-	"github.com/rios0rios0/autoupdate/internal/domain/entities"
 	"github.com/rios0rios0/autoupdate/internal/infrastructure/repositories/cmdrunner"
 	"github.com/rios0rios0/autoupdate/internal/infrastructure/repositories/gitlocal"
+	"github.com/rios0rios0/autoupdate/internal/support"
 )
 
 // localCmdRunner is the package-level command runner for local-mode upgrade scripts.
@@ -217,10 +217,8 @@ func runLanguageUpgradeScript(
 	vCtx *versionContext,
 	opts LocalUpgradeOptions,
 ) (string, error) {
-	changelogFile := prepareLocalChangelog(repoDir, vCtx)
-	if changelogFile != "" {
-		defer os.Remove(changelogFile)
-	}
+	changelog := support.StageLocalChangelog(repoDir, changelogEntries(vCtx))
+	defer changelog.Remove()
 
 	goBinary, err := findGoBinary()
 	if err != nil {
@@ -233,12 +231,12 @@ func runLanguageUpgradeScript(
 	}
 
 	params := localUpgradeParams{
-		BranchName:    vCtx.BranchName,
-		GoVersion:     vCtx.LatestVersion,
-		ChangelogFile: changelogFile,
-		AuthToken:     opts.AuthToken,
-		ProviderName:  opts.ProviderName,
-		HasConfigSH:   hasConfigSH,
+		BranchName:   vCtx.BranchName,
+		GoVersion:    vCtx.LatestVersion,
+		Changelog:    changelog,
+		AuthToken:    opts.AuthToken,
+		ProviderName: opts.ProviderName,
+		HasConfigSH:  hasConfigSH,
 	}
 
 	script := buildLocalUpgradeScript(params)
@@ -280,12 +278,14 @@ func runLanguageUpgradeScript(
 // --- local-mode internal types & helpers ---
 
 type localUpgradeParams struct {
-	BranchName    string
-	GoVersion     string
-	ChangelogFile string
-	AuthToken     string
-	ProviderName  string // git provider name (for credential setup)
-	HasConfigSH   bool   // whether the repo contains config.sh
+	BranchName string
+	GoVersion  string
+	// Changelog is the staged changelog payload the script copies into
+	// the clone; an empty value leaves the repository's changelog untouched.
+	Changelog    support.StagedChangelog
+	AuthToken    string
+	ProviderName string // git provider name (for credential setup)
+	HasConfigSH  bool   // whether the repo contains config.sh
 }
 
 // buildLocalUpgradeScript builds a bash script that performs only the
@@ -318,7 +318,7 @@ func buildLocalUpgradeScript(params localUpgradeParams) string {
 	// tag rewrite here, which could point FROM at a non-existent image.
 
 	// Changelog update (reuse existing)
-	writeChangelogUpdate(&sb)
+	sb.WriteString(support.ChangelogUpdateScript())
 
 	return sb.String()
 }
@@ -363,49 +363,6 @@ func buildLocalEnv(params localUpgradeParams, goBinary string) []string {
 			"GIT_HTTPS_TOKEN="+params.AuthToken,
 		)
 	}
-	if params.ChangelogFile != "" {
-		env = append(env, "CHANGELOG_FILE="+params.ChangelogFile)
-	}
+	env = append(env, params.Changelog.Env()...)
 	return env
-}
-
-// prepareLocalChangelog reads CHANGELOG.md from disk (if it exists),
-// inserts an upgrade entry, and writes the result to a temp file.
-// Returns the temp file path, or "" if no changelog update is needed.
-func prepareLocalChangelog(repoDir string, vCtx *versionContext) string {
-	content, err := os.ReadFile(filepath.Join(repoDir, "CHANGELOG.md"))
-	if err != nil {
-		return "" // no changelog present
-	}
-
-	var entry string
-	if vCtx.NeedsVersionUpgrade {
-		entry = fmt.Sprintf(
-			"- changed the Go version to `%s` and updated all module dependencies",
-			vCtx.LatestVersion,
-		)
-	} else {
-		entry = goChangelogEntryDeps
-	}
-
-	modified := entities.InsertChangelogEntry(string(content), []string{entry})
-	if modified == string(content) {
-		return ""
-	}
-
-	tmpFile, writeErr := os.CreateTemp("", "autoupdate-changelog-*.md")
-	if writeErr != nil {
-		logger.Warnf("[golang] Failed to create temp changelog file: %v", writeErr)
-		return ""
-	}
-
-	if _, writeErr = tmpFile.WriteString(modified); writeErr != nil {
-		_ = tmpFile.Close()
-		_ = os.Remove(tmpFile.Name())
-		logger.Warnf("[golang] Failed to write temp changelog: %v", writeErr)
-		return ""
-	}
-	_ = tmpFile.Close()
-
-	return tmpFile.Name()
 }

--- a/internal/infrastructure/repositories/java/export_test.go
+++ b/internal/infrastructure/repositories/java/export_test.go
@@ -87,14 +87,9 @@ func BuildEnv(params UpgradeParamsExported, repoDir string) []string {
 	return buildEnv(params, repoDir)
 }
 
-// PrepareChangelog is exported for testing.
-func PrepareChangelog(
-	ctx context.Context,
-	provider repositories.ProviderRepository,
-	repo entities.Repository,
-	vCtx *VersionContext,
-) string {
-	return prepareChangelog(ctx, provider, repo, vCtx)
+// ChangelogEntries is exported for testing.
+func ChangelogEntries(vCtx *VersionContext) []string {
+	return changelogEntries(vCtx)
 }
 
 // LogDryRun is exported for testing.
@@ -118,11 +113,6 @@ func OpenPullRequest(
 // WriteDockerfileUpdate is exported for testing.
 func WriteDockerfileUpdate(sb *strings.Builder) {
 	writeDockerfileUpdate(sb)
-}
-
-// WriteChangelogUpdate is exported for testing.
-func WriteChangelogUpdate(sb *strings.Builder) {
-	writeChangelogUpdate(sb)
 }
 
 // WriteCommitAndPush is exported for testing.

--- a/internal/infrastructure/repositories/java/java_updater_repository.go
+++ b/internal/infrastructure/repositories/java/java_updater_repository.go
@@ -161,10 +161,8 @@ func cloneAndUpgrade(
 	vCtx *versionContext,
 	buildSys string,
 ) (*upgradeResult, error) {
-	changelogFile := prepareChangelog(ctx, provider, repo, vCtx)
-	if changelogFile != "" {
-		defer os.Remove(changelogFile)
-	}
+	changelog := support.StageRemoteChangelog(ctx, provider, repo, changelogEntries(vCtx))
+	defer changelog.Remove()
 
 	cloneURL := provider.CloneURL(repo)
 	defaultBranch := strings.TrimPrefix(repo.DefaultBranch, "refs/heads/")
@@ -176,7 +174,7 @@ func cloneAndUpgrade(
 		JavaVersion:   vCtx.LatestVersion,
 		AuthToken:     provider.AuthToken(),
 		ProviderName:  provider.Name(),
-		ChangelogFile: changelogFile,
+		Changelog:     changelog,
 		BuildSystem:   buildSys,
 	})
 	if err != nil {
@@ -280,7 +278,7 @@ func (u *UpdaterRepository) ApplyUpdates(
 		return nil, repositories.ErrNoUpdatesNeeded
 	}
 
-	// Update CHANGELOG locally
+	// Record the upgrade in the repository's changelog.
 	var entry string
 	if javaVersionUpdated {
 		entry = fmt.Sprintf(
@@ -340,8 +338,10 @@ type upgradeParams struct {
 	JavaVersion   string
 	AuthToken     string
 	ProviderName  string
-	ChangelogFile string
-	BuildSystem   string // "gradle" or "maven"
+	// Changelog is the staged changelog payload the script copies into
+	// the clone; an empty value leaves the repository's changelog untouched.
+	Changelog   support.StagedChangelog
+	BuildSystem string // "gradle" or "maven"
 }
 
 type upgradeResult struct {
@@ -479,55 +479,17 @@ func resolveLocalVersionContext(ctx context.Context, repoDir string) *versionCon
 	}
 }
 
-// prepareChangelog reads the target repo's CHANGELOG.md (if it exists),
-// inserts an entry describing the Java upgrade, and writes the modified
-// content to a temp file.
-func prepareChangelog(
-	ctx context.Context,
-	provider repositories.ProviderRepository,
-	repo entities.Repository,
-	vCtx *versionContext,
-) string {
-	if !provider.HasFile(ctx, repo, "CHANGELOG.md") {
-		return ""
-	}
-
-	content, err := provider.GetFileContent(ctx, repo, "CHANGELOG.md")
-	if err != nil {
-		logger.Warnf("[java] Failed to read CHANGELOG.md: %v", err)
-		return ""
-	}
-
-	var entry string
+// changelogEntries renders the Keep a Changelog bullet describing the
+// upgrade. The staging helpers turn it into a chlog fragment when the
+// target repository uses that format instead.
+func changelogEntries(vCtx *versionContext) []string {
 	if vCtx.NeedsVersionUpgrade {
-		entry = fmt.Sprintf(
+		return []string{fmt.Sprintf(
 			"- changed the Java version to `%s` and updated all dependencies",
 			vCtx.LatestVersion,
-		)
-	} else {
-		entry = javaChangelogEntryDeps
+		)}
 	}
-
-	modified := entities.InsertChangelogEntry(content, []string{entry})
-	if modified == content {
-		return ""
-	}
-
-	tmpFile, writeErr := os.CreateTemp("", "autoupdate-changelog-*.md")
-	if writeErr != nil {
-		logger.Warnf("[java] Failed to create temp changelog file: %v", writeErr)
-		return ""
-	}
-
-	if _, writeErr = tmpFile.WriteString(modified); writeErr != nil {
-		_ = tmpFile.Close()
-		_ = os.Remove(tmpFile.Name())
-		logger.Warnf("[java] Failed to write temp changelog: %v", writeErr)
-		return ""
-	}
-	_ = tmpFile.Close()
-
-	return tmpFile.Name()
+	return []string{javaChangelogEntryDeps}
 }
 
 // --- clone + upgrade ---
@@ -609,8 +571,9 @@ func buildUpgradeScript(
 	// Update Dockerfile Java image tags
 	writeDockerfileUpdate(&sb)
 
-	// Overwrite CHANGELOG.md with the pre-generated content (if provided)
-	writeChangelogUpdate(&sb)
+	// Copy in the staged changelog: an edited CHANGELOG.md, or a chlog
+	// fragment when the target repository uses that format.
+	sb.WriteString(support.ChangelogUpdateScript())
 
 	// Check for changes and commit/push
 	writeCommitAndPush(&sb)
@@ -746,18 +709,6 @@ func writeDockerfileUpdate(sb *strings.Builder) {
 	sb.WriteString("fi\n\n")
 }
 
-func writeChangelogUpdate(sb *strings.Builder) {
-	sb.WriteString("# Update CHANGELOG.md only if the upgrade produced actual changes.\n")
-	sb.WriteString("if [ -n \"${CHANGELOG_FILE:-}\" ] && [ -f \"$CHANGELOG_FILE\" ]; then\n")
-	sb.WriteString("    if [ -n \"$(git status --porcelain)\" ]; then\n")
-	sb.WriteString("        echo \"Updating CHANGELOG.md...\"\n")
-	sb.WriteString("        cp \"$CHANGELOG_FILE\" CHANGELOG.md\n")
-	sb.WriteString("    else\n")
-	sb.WriteString("        echo \"No dependency changes detected, skipping CHANGELOG update.\"\n")
-	sb.WriteString("    fi\n")
-	sb.WriteString("fi\n\n")
-}
-
 func writeCommitAndPush(sb *strings.Builder) {
 	sb.WriteString("if [ -n \"$(git status --porcelain)\" ]; then\n")
 	sb.WriteString("    echo \"Changes detected, committing and pushing...\"\n")
@@ -790,9 +741,7 @@ func buildEnv(params upgradeParams, repoDir string) []string {
 	if params.JavaVersion != "" {
 		env = append(env, "JAVA_VERSION="+params.JavaVersion)
 	}
-	if params.ChangelogFile != "" {
-		env = append(env, "CHANGELOG_FILE="+params.ChangelogFile)
-	}
+	env = append(env, params.Changelog.Env()...)
 	return env
 }
 

--- a/internal/infrastructure/repositories/javascript/export_test.go
+++ b/internal/infrastructure/repositories/javascript/export_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rios0rios0/autoupdate/internal/domain/entities"
 	"github.com/rios0rios0/autoupdate/internal/domain/repositories"
 	"github.com/rios0rios0/autoupdate/internal/infrastructure/repositories/cmdrunner"
+	"github.com/rios0rios0/autoupdate/internal/support"
 )
 
 // HasOnlyLockfileVersionChanges is exported for testing.
@@ -22,8 +23,12 @@ func IsPackageLockOnlyVersionSync(ctx context.Context, repoDir string) bool {
 }
 
 // RevertWorkingTreeChanges is exported for testing.
-func RevertWorkingTreeChanges(ctx context.Context, repoDir string) {
-	revertWorkingTreeChanges(ctx, repoDir)
+func RevertWorkingTreeChanges(
+	ctx context.Context,
+	repoDir string,
+	changelog support.StagedChangelog,
+) {
+	revertWorkingTreeChanges(ctx, repoDir, changelog)
 }
 
 // ParseNodeVersionFile is exported for testing.
@@ -78,16 +83,6 @@ func ReadCurrentNodeVersion(
 	return readCurrentNodeVersion(ctx, provider, repo)
 }
 
-// PrepareChangelog is exported for testing.
-func PrepareChangelog(
-	ctx context.Context,
-	provider repositories.ProviderRepository,
-	repo entities.Repository,
-	vCtx *versionContext,
-) string {
-	return prepareChangelog(ctx, provider, repo, vCtx)
-}
-
 // BuildUpgradeScript is exported for testing.
 func BuildUpgradeScript(params upgradeParams, repoDir string) string {
 	return buildUpgradeScript(params, repoDir)
@@ -111,13 +106,6 @@ func WriteJSUpgradeCommands(params upgradeParams) string {
 func WriteDockerfileUpdate() string {
 	var sb strings.Builder
 	writeDockerfileUpdate(&sb)
-	return sb.String()
-}
-
-// WriteChangelogUpdate is exported for testing.
-func WriteChangelogUpdate() string {
-	var sb strings.Builder
-	writeChangelogUpdate(&sb)
 	return sb.String()
 }
 
@@ -182,11 +170,6 @@ func HandleDryRunLocal(vCtx *versionContext, repoDir, pkgMgr string) *LocalResul
 	return handleDryRunLocal(vCtx, repoDir, pkgMgr)
 }
 
-// PrepareLocalChangelog is exported for testing.
-func PrepareLocalChangelog(repoDir string, vCtx *versionContext) string {
-	return prepareLocalChangelog(repoDir, vCtx)
-}
-
 // SetLocalCmdRunner overrides the package-level local command runner for testing.
 func SetLocalCmdRunner(r cmdrunner.Runner) func() {
 	old := localCmdRunner
@@ -201,6 +184,12 @@ func RunLanguageUpgradeScript(
 	vCtx *versionContext,
 	pkgMgr string,
 	opts LocalUpgradeOptions,
+	changelog support.StagedChangelog,
 ) (string, error) {
-	return runLanguageUpgradeScript(ctx, repoDir, vCtx, pkgMgr, opts)
+	return runLanguageUpgradeScript(ctx, repoDir, vCtx, pkgMgr, opts, changelog)
+}
+
+// ChangelogEntries is exported for testing.
+func ChangelogEntries(vCtx *versionContext) []string {
+	return changelogEntries(vCtx)
 }

--- a/internal/infrastructure/repositories/javascript/javascript_updater_repository.go
+++ b/internal/infrastructure/repositories/javascript/javascript_updater_repository.go
@@ -155,10 +155,8 @@ func cloneAndUpgrade(
 	vCtx *versionContext,
 	pkgMgr string,
 ) (*upgradeResult, error) {
-	changelogFile := prepareChangelog(ctx, provider, repo, vCtx)
-	if changelogFile != "" {
-		defer os.Remove(changelogFile)
-	}
+	changelog := support.StageRemoteChangelog(ctx, provider, repo, changelogEntries(vCtx))
+	defer changelog.Remove()
 
 	cloneURL := provider.CloneURL(repo)
 	defaultBranch := strings.TrimPrefix(repo.DefaultBranch, "refs/heads/")
@@ -170,7 +168,7 @@ func cloneAndUpgrade(
 		NodeVersion:    vCtx.LatestVersion,
 		AuthToken:      provider.AuthToken(),
 		ProviderName:   provider.Name(),
-		ChangelogFile:  changelogFile,
+		Changelog:      changelog,
 		PackageManager: pkgMgr,
 	})
 	if err != nil {
@@ -279,12 +277,14 @@ func (u *UpdaterRepository) ApplyUpdates(
 		logger.Infof(
 			"[javascript] Only cosmetic lockfile version changes detected (project version sync), skipping",
 		)
-		revertWorkingTreeChanges(ctx, repoDir)
+		// This flow writes the changelog itself, after this check, so there is
+		// no staged payload to undo.
+		revertWorkingTreeChanges(ctx, repoDir, support.StagedChangelog{})
 		return nil, repositories.ErrNoUpdatesNeeded
 	}
 	logger.Infof("[javascript] Filesystem changes detected, proceeding with commit")
 
-	// Update CHANGELOG locally
+	// Record the upgrade in the repository's changelog.
 	var entry string
 	if nodeVersionUpdated {
 		entry = fmt.Sprintf(
@@ -337,13 +337,15 @@ type versionContext struct {
 }
 
 type upgradeParams struct {
-	CloneURL       string
-	DefaultBranch  string
-	BranchName     string
-	NodeVersion    string
-	AuthToken      string
-	ProviderName   string
-	ChangelogFile  string
+	CloneURL      string
+	DefaultBranch string
+	BranchName    string
+	NodeVersion   string
+	AuthToken     string
+	ProviderName  string
+	// Changelog is the staged changelog payload the script copies into
+	// the clone; an empty value leaves the repository's changelog untouched.
+	Changelog      support.StagedChangelog
 	PackageManager string // "npm", "yarn", or "pnpm"
 }
 
@@ -461,55 +463,17 @@ func readCurrentNodeVersion(
 	return ""
 }
 
-// prepareChangelog reads the target repo's CHANGELOG.md (if it exists),
-// inserts an entry describing the JavaScript upgrade, and writes the modified
-// content to a temp file.
-func prepareChangelog(
-	ctx context.Context,
-	provider repositories.ProviderRepository,
-	repo entities.Repository,
-	vCtx *versionContext,
-) string {
-	if !provider.HasFile(ctx, repo, "CHANGELOG.md") {
-		return ""
-	}
-
-	content, err := provider.GetFileContent(ctx, repo, "CHANGELOG.md")
-	if err != nil {
-		logger.Warnf("[javascript] Failed to read CHANGELOG.md: %v", err)
-		return ""
-	}
-
-	var entry string
+// changelogEntries renders the Keep a Changelog bullet describing the
+// upgrade. The staging helpers turn it into a chlog fragment when the
+// target repository uses that format instead.
+func changelogEntries(vCtx *versionContext) []string {
 	if vCtx.NeedsVersionUpgrade {
-		entry = fmt.Sprintf(
+		return []string{fmt.Sprintf(
 			"- changed the Node.js version to `%s` and updated all JavaScript dependencies",
 			vCtx.LatestVersion,
-		)
-	} else {
-		entry = jsChangelogEntryDeps
+		)}
 	}
-
-	modified := entities.InsertChangelogEntry(content, []string{entry})
-	if modified == content {
-		return ""
-	}
-
-	tmpFile, writeErr := os.CreateTemp("", "autoupdate-changelog-*.md")
-	if writeErr != nil {
-		logger.Warnf("[javascript] Failed to create temp changelog file: %v", writeErr)
-		return ""
-	}
-
-	if _, writeErr = tmpFile.WriteString(modified); writeErr != nil {
-		_ = tmpFile.Close()
-		_ = os.Remove(tmpFile.Name())
-		logger.Warnf("[javascript] Failed to write temp changelog: %v", writeErr)
-		return ""
-	}
-	_ = tmpFile.Close()
-
-	return tmpFile.Name()
+	return []string{jsChangelogEntryDeps}
 }
 
 // --- clone + upgrade ---
@@ -590,8 +554,9 @@ func buildUpgradeScript(
 	// Update Dockerfile node image tags
 	writeDockerfileUpdate(&sb)
 
-	// Overwrite CHANGELOG.md with the pre-generated content
-	writeChangelogUpdate(&sb)
+	// Copy in the staged changelog: an edited CHANGELOG.md, or a chlog
+	// fragment when the target repository uses that format.
+	sb.WriteString(support.ChangelogUpdateScript())
 
 	// Check for changes and commit/push
 	writeCommitAndPush(&sb)
@@ -685,18 +650,6 @@ func writeDockerfileUpdate(sb *strings.Builder) {
 	sb.WriteString("fi\n\n")
 }
 
-func writeChangelogUpdate(sb *strings.Builder) {
-	sb.WriteString("# Update CHANGELOG.md only if the upgrade produced actual changes.\n")
-	sb.WriteString("if [ -n \"${CHANGELOG_FILE:-}\" ] && [ -f \"$CHANGELOG_FILE\" ]; then\n")
-	sb.WriteString("    if [ -n \"$(git status --porcelain)\" ]; then\n")
-	sb.WriteString("        echo \"Updating CHANGELOG.md...\"\n")
-	sb.WriteString("        cp \"$CHANGELOG_FILE\" CHANGELOG.md\n")
-	sb.WriteString("    else\n")
-	sb.WriteString("        echo \"No dependency changes detected, skipping CHANGELOG update.\"\n")
-	sb.WriteString("    fi\n")
-	sb.WriteString("fi\n\n")
-}
-
 func writeCommitAndPush(sb *strings.Builder) {
 	sb.WriteString("if [ -n \"$(git status --porcelain)\" ]; then\n")
 
@@ -770,9 +723,7 @@ func buildEnv(params upgradeParams, repoDir string) []string {
 	if params.NodeVersion != "" {
 		env = append(env, "NODE_VERSION="+params.NodeVersion)
 	}
-	if params.ChangelogFile != "" {
-		env = append(env, "CHANGELOG_FILE="+params.ChangelogFile)
-	}
+	env = append(env, params.Changelog.Env()...)
 	return env
 }
 

--- a/internal/infrastructure/repositories/javascript/javascript_updater_repository_test.go
+++ b/internal/infrastructure/repositories/javascript/javascript_updater_repository_test.go
@@ -4,7 +4,6 @@ package javascript_test
 
 import (
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -13,6 +12,7 @@ import (
 
 	"github.com/rios0rios0/autoupdate/internal/domain/entities"
 	jsUpdater "github.com/rios0rios0/autoupdate/internal/infrastructure/repositories/javascript"
+	"github.com/rios0rios0/autoupdate/internal/support"
 	"github.com/rios0rios0/autoupdate/test/infrastructure/repositorydoubles"
 )
 
@@ -376,107 +376,35 @@ func TestReadCurrentNodeVersion(t *testing.T) {
 	})
 }
 
-func TestPrepareChangelog(t *testing.T) {
+func TestChangelogEntries(t *testing.T) {
 	t.Parallel()
 
-	t.Run("should return empty string when CHANGELOG.md does not exist", func(t *testing.T) {
+	t.Run("should describe the version upgrade when one is needed", func(t *testing.T) {
 		t.Parallel()
 
 		// given
-		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
-			WithExistingFiles(map[string]bool{}).
-			BuildSpy()
-		repo := entities.Repository{Organization: "org", Name: "repo"}
-		vCtx := &jsUpdater.VersionContext{
-			LatestVersion:       "20.18.0",
-			NeedsVersionUpgrade: true,
-			BranchName:          "chore/upgrade-node-20.18.0",
-		}
+		vCtx := &jsUpdater.VersionContext{LatestVersion: "20.18.0", NeedsVersionUpgrade: true}
 
 		// when
-		result := jsUpdater.PrepareChangelog(t.Context(), provider, repo, vCtx)
+		entries := jsUpdater.ChangelogEntries(vCtx)
 
 		// then
-		assert.Equal(t, "", result)
+		assert.Equal(t, []string{
+			"- changed the Node.js version to `20.18.0` and updated all JavaScript dependencies",
+		}, entries)
 	})
 
-	t.Run("should create temp file with modified changelog when version upgrade is needed", func(t *testing.T) {
+	t.Run("should describe only the dependencies when no version upgrade is needed", func(t *testing.T) {
 		t.Parallel()
 
 		// given
-		changelogContent := "# Changelog\n\n## [Unreleased]\n\n## [1.0.0] - 2024-01-01\n"
-		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
-			WithExistingFiles(map[string]bool{"CHANGELOG.md": true}).
-			WithFileContents(map[string]string{"CHANGELOG.md": changelogContent}).
-			BuildSpy()
-		repo := entities.Repository{Organization: "org", Name: "repo"}
-		vCtx := &jsUpdater.VersionContext{
-			LatestVersion:       "20.18.0",
-			NeedsVersionUpgrade: true,
-			BranchName:          "chore/upgrade-node-20.18.0",
-		}
+		vCtx := &jsUpdater.VersionContext{LatestVersion: "20.18.0", NeedsVersionUpgrade: false}
 
 		// when
-		result := jsUpdater.PrepareChangelog(t.Context(), provider, repo, vCtx)
+		entries := jsUpdater.ChangelogEntries(vCtx)
 
 		// then
-		if result != "" {
-			defer os.Remove(result)
-			content, err := os.ReadFile(result)
-			require.NoError(t, err)
-			assert.Contains(t, string(content), "20.18.0")
-			assert.Contains(t, string(content), "JavaScript dependencies")
-		}
-	})
-
-	t.Run("should create temp file with deps-only changelog entry when no version upgrade", func(t *testing.T) {
-		t.Parallel()
-
-		// given
-		changelogContent := "# Changelog\n\n## [Unreleased]\n\n## [1.0.0] - 2024-01-01\n"
-		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
-			WithExistingFiles(map[string]bool{"CHANGELOG.md": true}).
-			WithFileContents(map[string]string{"CHANGELOG.md": changelogContent}).
-			BuildSpy()
-		repo := entities.Repository{Organization: "org", Name: "repo"}
-		vCtx := &jsUpdater.VersionContext{
-			LatestVersion:       "20.18.0",
-			NeedsVersionUpgrade: false,
-			BranchName:          "chore/upgrade-js-deps",
-		}
-
-		// when
-		result := jsUpdater.PrepareChangelog(t.Context(), provider, repo, vCtx)
-
-		// then
-		if result != "" {
-			defer os.Remove(result)
-			content, err := os.ReadFile(result)
-			require.NoError(t, err)
-			assert.Contains(t, string(content), "JavaScript dependencies")
-		}
-	})
-
-	t.Run("should return empty string when GetFileContent fails", func(t *testing.T) {
-		t.Parallel()
-
-		// given
-		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
-			WithExistingFiles(map[string]bool{"CHANGELOG.md": true}).
-			WithFileContentErr(assert.AnError).
-			BuildSpy()
-		repo := entities.Repository{Organization: "org", Name: "repo"}
-		vCtx := &jsUpdater.VersionContext{
-			LatestVersion:       "20.18.0",
-			NeedsVersionUpgrade: true,
-			BranchName:          "chore/upgrade-node-20.18.0",
-		}
-
-		// when
-		result := jsUpdater.PrepareChangelog(t.Context(), provider, repo, vCtx)
-
-		// then
-		assert.Equal(t, "", result)
+		assert.Equal(t, []string{"- changed the JavaScript dependencies to their latest versions"}, entries)
 	})
 }
 
@@ -743,33 +671,6 @@ func TestWriteDockerfileUpdate(t *testing.T) {
 	})
 }
 
-func TestWriteChangelogUpdate(t *testing.T) {
-	t.Parallel()
-
-	t.Run("should contain CHANGELOG.md copy logic", func(t *testing.T) {
-		t.Parallel()
-
-		// given / when
-		result := jsUpdater.WriteChangelogUpdate()
-
-		// then
-		assert.NotEmpty(t, result)
-		assert.Contains(t, result, "CHANGELOG_FILE")
-		assert.Contains(t, result, "CHANGELOG.md")
-		assert.Contains(t, result, "cp")
-	})
-
-	t.Run("should check for git changes before updating changelog", func(t *testing.T) {
-		t.Parallel()
-
-		// given / when
-		result := jsUpdater.WriteChangelogUpdate()
-
-		// then
-		assert.Contains(t, result, "git status --porcelain")
-	})
-}
-
 func TestWriteCommitAndPush(t *testing.T) {
 	t.Parallel()
 
@@ -877,7 +778,7 @@ func TestBuildEnv(t *testing.T) {
 			AuthToken:      "test-token",
 			ProviderName:   "github",
 			PackageManager: "npm",
-			ChangelogFile:  "",
+			Changelog:      support.StagedChangelog{},
 		}
 
 		// when
@@ -900,7 +801,7 @@ func TestBuildEnv(t *testing.T) {
 			AuthToken:      "test-token",
 			ProviderName:   "github",
 			PackageManager: "npm",
-			ChangelogFile:  "/tmp/changelog.md",
+			Changelog:      support.StagedChangelog{TempPath: "/tmp/changelog.md", RepoPath: "CHANGELOG.md"},
 		}
 
 		// when
@@ -1435,7 +1336,7 @@ func TestBuildLocalEnv(t *testing.T) {
 		params := jsUpdater.LocalUpgradeParamsExported{
 			BranchName:     "chore/upgrade-js-deps",
 			PackageManager: "npm",
-			ChangelogFile:  "/tmp/changelog.md",
+			Changelog:      support.StagedChangelog{TempPath: "/tmp/changelog.md", RepoPath: "CHANGELOG.md"},
 		}
 
 		// when
@@ -1622,41 +1523,3 @@ func TestHandleDryRunLocal(t *testing.T) {
 		assert.False(t, result.NodeVersionUpdated)
 	})
 }
-
-func TestPrepareLocalChangelogJS(t *testing.T) {
-	t.Parallel()
-
-	t.Run("should return temp file when CHANGELOG.md exists", func(t *testing.T) {
-		t.Parallel()
-
-		// given
-		root := t.TempDir()
-		changelog := "# Changelog\n\n## [Unreleased]\n\n## [1.0.0] - 2026-01-01\n"
-		require.NoError(t, os.WriteFile(filepath.Join(root, "CHANGELOG.md"), []byte(changelog), 0o600))
-		vCtx := &jsUpdater.VersionContext{LatestVersion: "20.18.0", NeedsVersionUpgrade: true}
-
-		// when
-		result := jsUpdater.PrepareLocalChangelog(root, vCtx)
-
-		// then
-		assert.NotEmpty(t, result)
-		if result != "" {
-			defer os.Remove(result)
-		}
-	})
-
-	t.Run("should return empty when no CHANGELOG.md", func(t *testing.T) {
-		t.Parallel()
-
-		// given
-		root := t.TempDir()
-		vCtx := &jsUpdater.VersionContext{LatestVersion: "20.18.0", NeedsVersionUpgrade: true}
-
-		// when
-		result := jsUpdater.PrepareLocalChangelog(root, vCtx)
-
-		// then
-		assert.Empty(t, result)
-	})
-}
-

--- a/internal/infrastructure/repositories/javascript/local.go
+++ b/internal/infrastructure/repositories/javascript/local.go
@@ -10,9 +10,9 @@ import (
 
 	logger "github.com/sirupsen/logrus"
 
-	"github.com/rios0rios0/autoupdate/internal/domain/entities"
 	"github.com/rios0rios0/autoupdate/internal/infrastructure/repositories/cmdrunner"
 	"github.com/rios0rios0/autoupdate/internal/infrastructure/repositories/gitlocal"
+	"github.com/rios0rios0/autoupdate/internal/support"
 )
 
 // localCmdRunner is the package-level command runner for local-mode upgrade scripts.
@@ -187,7 +187,12 @@ func executeLocalUpgrade(
 	}
 
 	// --- Language Operations (bash) ---
-	outputStr, runErr := runLanguageUpgradeScript(ctx, repoDir, vCtx, pkgMgr, opts)
+	// The changelog is staged here rather than inside the script runner so this
+	// function, which decides whether to keep the run, can also undo it.
+	changelog := support.StageLocalChangelog(repoDir, changelogEntries(vCtx))
+	defer changelog.Remove()
+
+	outputStr, runErr := runLanguageUpgradeScript(ctx, repoDir, vCtx, pkgMgr, opts, changelog)
 	if runErr != nil {
 		return nil, runErr
 	}
@@ -199,7 +204,7 @@ func executeLocalUpgrade(
 		logger.Infof(
 			"[javascript] Only cosmetic lockfile version changes detected (project version sync), skipping",
 		)
-		revertWorkingTreeChanges(ctx, repoDir)
+		revertWorkingTreeChanges(ctx, repoDir, changelog)
 		return &LocalResult{
 			HasChanges:     false,
 			LatestVersion:  vCtx.LatestVersion,
@@ -243,16 +248,12 @@ func runLanguageUpgradeScript(
 	vCtx *versionContext,
 	pkgMgr string,
 	opts LocalUpgradeOptions,
+	changelog support.StagedChangelog,
 ) (string, error) {
-	changelogFile := prepareLocalChangelog(repoDir, vCtx)
-	if changelogFile != "" {
-		defer os.Remove(changelogFile)
-	}
-
 	params := localUpgradeParams{
 		BranchName:     vCtx.BranchName,
 		NodeVersion:    vCtx.LatestVersion,
-		ChangelogFile:  changelogFile,
+		Changelog:      changelog,
 		AuthToken:      opts.AuthToken,
 		ProviderName:   opts.ProviderName,
 		PackageManager: pkgMgr,
@@ -297,9 +298,11 @@ func runLanguageUpgradeScript(
 // --- local-mode internal types & helpers ---
 
 type localUpgradeParams struct {
-	BranchName     string
-	NodeVersion    string
-	ChangelogFile  string
+	BranchName  string
+	NodeVersion string
+	// Changelog is the staged changelog payload the script copies into
+	// the clone; an empty value leaves the repository's changelog untouched.
+	Changelog      support.StagedChangelog
 	AuthToken      string
 	ProviderName   string
 	PackageManager string
@@ -327,7 +330,7 @@ func buildLocalUpgradeScript(params localUpgradeParams) string {
 	writeDockerfileUpdate(&sb)
 
 	// Changelog update
-	writeChangelogUpdate(&sb)
+	sb.WriteString(support.ChangelogUpdateScript())
 
 	return sb.String()
 }
@@ -376,48 +379,6 @@ func buildLocalEnv(params localUpgradeParams) []string {
 			"GIT_HTTPS_TOKEN="+params.AuthToken,
 		)
 	}
-	if params.ChangelogFile != "" {
-		env = append(env, "CHANGELOG_FILE="+params.ChangelogFile)
-	}
+	env = append(env, params.Changelog.Env()...)
 	return env
-}
-
-// prepareLocalChangelog reads CHANGELOG.md from disk (if it exists),
-// inserts an upgrade entry, and writes the result to a temp file.
-func prepareLocalChangelog(repoDir string, vCtx *versionContext) string {
-	content, err := os.ReadFile(filepath.Join(repoDir, "CHANGELOG.md"))
-	if err != nil {
-		return "" // no changelog present
-	}
-
-	var entry string
-	if vCtx.NeedsVersionUpgrade {
-		entry = fmt.Sprintf(
-			"- changed the Node.js version to `%s` and updated all JavaScript dependencies",
-			vCtx.LatestVersion,
-		)
-	} else {
-		entry = jsChangelogEntryDeps
-	}
-
-	modified := entities.InsertChangelogEntry(string(content), []string{entry})
-	if modified == string(content) {
-		return ""
-	}
-
-	tmpFile, writeErr := os.CreateTemp("", "autoupdate-changelog-*.md")
-	if writeErr != nil {
-		logger.Warnf("[javascript] Failed to create temp changelog file: %v", writeErr)
-		return ""
-	}
-
-	if _, writeErr = tmpFile.WriteString(modified); writeErr != nil {
-		_ = tmpFile.Close()
-		_ = os.Remove(tmpFile.Name())
-		logger.Warnf("[javascript] Failed to write temp changelog: %v", writeErr)
-		return ""
-	}
-	_ = tmpFile.Close()
-
-	return tmpFile.Name()
 }

--- a/internal/infrastructure/repositories/javascript/lockfile_check.go
+++ b/internal/infrastructure/repositories/javascript/lockfile_check.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	logger "github.com/sirupsen/logrus"
+
+	"github.com/rios0rios0/autoupdate/internal/support"
 )
 
 // hasOnlyLockfileVersionChanges returns true when the only uncommitted
@@ -29,10 +31,12 @@ func hasOnlyLockfileVersionChanges(ctx context.Context, repoDir string) bool {
 			if !isPackageLockOnlyVersionSync(ctx, repoDir) {
 				return false
 			}
-		case "CHANGELOG.md":
+		case support.ChangelogFileName:
 			// Tolerate auto-generated changelog updates alongside cosmetic
-			// lockfile syncs — writeChangelogUpdate copies the changelog
-			// whenever git status is non-empty, even for cosmetic-only changes.
+			// lockfile syncs — the upgrade script copies the changelog whenever
+			// git status is non-empty, even for cosmetic-only changes. A chlog
+			// fragment needs no case here: it is a new untracked file, so
+			// "git diff" never reports it.
 		default:
 			// Any non-lockfile change (or yarn.lock / pnpm-lock.yaml which
 			// do not carry a project version field) is a real change.
@@ -144,9 +148,19 @@ func gitShowHEAD(ctx context.Context, repoDir, filePath string) ([]byte, error) 
 	return cmd.Output()
 }
 
-// revertWorkingTreeChanges discards all unstaged changes in the
-// working tree, restoring it to the HEAD state.
-func revertWorkingTreeChanges(ctx context.Context, repoDir string) {
+// revertWorkingTreeChanges discards all unstaged changes in the working tree,
+// restoring it to the HEAD state.
+//
+// The staged changelog is discarded first: a chlog fragment the upgrade script
+// already copied in is a new untracked file, so the checkout below would leave
+// it behind in the repository this run decided not to touch.
+func revertWorkingTreeChanges(
+	ctx context.Context,
+	repoDir string,
+	changelog support.StagedChangelog,
+) {
+	changelog.Discard(repoDir)
+
 	cmd := exec.CommandContext(ctx, "git", "checkout", "--", ".")
 	cmd.Dir = repoDir
 	if err := cmd.Run(); err != nil {

--- a/internal/infrastructure/repositories/javascript/lockfile_check_test.go
+++ b/internal/infrastructure/repositories/javascript/lockfile_check_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/rios0rios0/autoupdate/internal/infrastructure/repositories/javascript"
+	"github.com/rios0rios0/autoupdate/internal/support"
 )
 
 // initGitRepo creates a bare-minimum git repo in dir with an initial commit
@@ -288,10 +289,67 @@ func TestRevertWorkingTreeChanges(t *testing.T) {
 		))
 
 		// when
-		javascript.RevertWorkingTreeChanges(t.Context(), dir)
+		javascript.RevertWorkingTreeChanges(t.Context(), dir, support.StagedChangelog{})
 
 		// then
 		content, err := os.ReadFile(filepath.Join(dir, "package-lock.json"))
+		require.NoError(t, err)
+		assert.Equal(t, original, string(content))
+	})
+
+	t.Run("should delete the chlog fragment the upgrade script copied in", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		dir := t.TempDir()
+		initGitRepo(t, dir, map[string]string{"package-lock.json": packageLockWithVersion("1.0.0", "4.17.21")})
+
+		fragment := ".changes/unreleased/1748359200-a1b2.yaml"
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, ".changes", "unreleased"), 0o700))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, filepath.FromSlash(fragment)),
+			[]byte("kind: Changed\nbody: changed a dependency\n"),
+			0o600,
+		))
+
+		// when
+		javascript.RevertWorkingTreeChanges(t.Context(), dir, support.StagedChangelog{
+			TempPath: filepath.Join(t.TempDir(), "staged.yaml"),
+			RepoPath: fragment,
+			Fragment: true,
+		})
+
+		// then
+		_, err := os.Stat(filepath.Join(dir, filepath.FromSlash(fragment)))
+		assert.True(t, os.IsNotExist(err),
+			"an untracked fragment survives the checkout, so it has to be deleted")
+	})
+
+	t.Run("should leave an edited CHANGELOG.md to the checkout", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		dir := t.TempDir()
+		original := "# Changelog\n\n## [Unreleased]\n"
+		initGitRepo(t, dir, map[string]string{
+			"package-lock.json": packageLockWithVersion("1.0.0", "4.17.21"),
+			"CHANGELOG.md":      original,
+		})
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, "CHANGELOG.md"),
+			[]byte(original+"\n### Changed\n\n- changed a dependency\n"),
+			0o600,
+		))
+
+		// when
+		javascript.RevertWorkingTreeChanges(t.Context(), dir, support.StagedChangelog{
+			TempPath: filepath.Join(t.TempDir(), "staged.md"),
+			RepoPath: "CHANGELOG.md",
+		})
+
+		// then
+		content, err := os.ReadFile(filepath.Join(dir, "CHANGELOG.md"))
 		require.NoError(t, err)
 		assert.Equal(t, original, string(content))
 	})

--- a/internal/infrastructure/repositories/pipeline/pipeline_updater_repository.go
+++ b/internal/infrastructure/repositories/pipeline/pipeline_updater_repository.go
@@ -1034,9 +1034,10 @@ func generatePRDescription(tasks []upgradeTask) string {
 	return sb.String()
 }
 
-// appendChangelogEntry reads CHANGELOG.md (if present), inserts entries
-// describing the pipeline version upgrades, and appends the modified file
-// to the change set.
+// appendChangelogEntry records the pipeline version upgrades in the target
+// repo's changelog and appends the resulting file to the change set. The
+// format -- Keep a Changelog or chlog fragments -- is decided by the shared
+// helper from what the repository itself commits.
 func appendChangelogEntry(
 	ctx context.Context,
 	provider repositories.ProviderRepository,
@@ -1044,16 +1045,6 @@ func appendChangelogEntry(
 	upgrades []upgradeTask,
 	fileChanges []entities.FileChange,
 ) []entities.FileChange {
-	if !provider.HasFile(ctx, repo, "CHANGELOG.md") {
-		return fileChanges
-	}
-
-	content, err := provider.GetFileContent(ctx, repo, "CHANGELOG.md")
-	if err != nil {
-		logger.Warnf("[pipeline] Failed to read CHANGELOG.md: %v", err)
-		return fileChanges
-	}
-
 	entries := make([]string, 0, len(upgrades))
 	for _, up := range upgrades {
 		entries = append(entries, fmt.Sprintf(
@@ -1062,14 +1053,5 @@ func appendChangelogEntry(
 		))
 	}
 
-	modified := entities.InsertChangelogEntry(content, entries)
-	if modified == content {
-		return fileChanges
-	}
-
-	return append(fileChanges, entities.FileChange{
-		Path:       "CHANGELOG.md",
-		Content:    modified,
-		ChangeType: "edit",
-	})
+	return support.RemoteChangelogChanges(ctx, provider, repo, entries, fileChanges)
 }

--- a/internal/infrastructure/repositories/python/export_test.go
+++ b/internal/infrastructure/repositories/python/export_test.go
@@ -114,14 +114,9 @@ func BuildEnv(params UpgradeParamsExported, repoDir string) []string {
 	return buildEnv(params, repoDir)
 }
 
-// PrepareChangelog is exported for testing.
-func PrepareChangelog(
-	ctx context.Context,
-	provider repositories.ProviderRepository,
-	repo entities.Repository,
-	vCtx *VersionContext,
-) string {
-	return prepareChangelog(ctx, provider, repo, vCtx)
+// ChangelogEntries is exported for testing.
+func ChangelogEntries(vCtx *VersionContext) []string {
+	return changelogEntries(vCtx)
 }
 
 // LogDryRun is exported for testing.
@@ -146,11 +141,6 @@ func WriteDockerfileUpdate(sb *strings.Builder) {
 	writeDockerfileUpdate(sb)
 }
 
-// WriteChangelogUpdate is exported for testing.
-func WriteChangelogUpdate(sb *strings.Builder) {
-	writeChangelogUpdate(sb)
-}
-
 // WriteCommitAndPush is exported for testing.
 func WriteCommitAndPush(sb *strings.Builder) {
 	writeCommitAndPush(sb)
@@ -169,11 +159,6 @@ func WriteLocalAuth(sb *strings.Builder, params LocalUpgradeParamsExported) {
 // HandleDryRun is exported for testing.
 func HandleDryRun(vCtx *VersionContext, repoDir string) *LocalResult {
 	return handleDryRun(vCtx, repoDir)
-}
-
-// PrepareLocalChangelog is exported for testing.
-func PrepareLocalChangelog(repoDir string, vCtx *VersionContext) string {
-	return prepareLocalChangelog(repoDir, vCtx)
 }
 
 // FindPythonBinary is exported for testing.

--- a/internal/infrastructure/repositories/python/local.go
+++ b/internal/infrastructure/repositories/python/local.go
@@ -10,9 +10,9 @@ import (
 
 	logger "github.com/sirupsen/logrus"
 
-	"github.com/rios0rios0/autoupdate/internal/domain/entities"
 	"github.com/rios0rios0/autoupdate/internal/infrastructure/repositories/cmdrunner"
 	"github.com/rios0rios0/autoupdate/internal/infrastructure/repositories/gitlocal"
+	"github.com/rios0rios0/autoupdate/internal/support"
 )
 
 // localCmdRunner is the package-level command runner for local-mode upgrade scripts.
@@ -197,10 +197,8 @@ func runLanguageUpgradeScript(
 	vCtx *versionContext,
 	opts LocalUpgradeOptions,
 ) (string, error) {
-	changelogFile := prepareLocalChangelog(repoDir, vCtx)
-	if changelogFile != "" {
-		defer os.Remove(changelogFile)
-	}
+	changelog := support.StageLocalChangelog(repoDir, changelogEntries(vCtx))
+	defer changelog.Remove()
 
 	pythonBinary, err := findPythonBinary()
 	if err != nil {
@@ -220,7 +218,7 @@ func runLanguageUpgradeScript(
 	params := localUpgradeParams{
 		BranchName:      vCtx.BranchName,
 		PythonVersion:   vCtx.LatestVersion,
-		ChangelogFile:   changelogFile,
+		Changelog:       changelog,
 		AuthToken:       opts.AuthToken,
 		ProviderName:    opts.ProviderName,
 		HasRequirements: hasRequirements,
@@ -268,9 +266,11 @@ func runLanguageUpgradeScript(
 // --- local-mode internal types & helpers ---
 
 type localUpgradeParams struct {
-	BranchName      string
-	PythonVersion   string
-	ChangelogFile   string
+	BranchName    string
+	PythonVersion string
+	// Changelog is the staged changelog payload the script copies into
+	// the clone; an empty value leaves the repository's changelog untouched.
+	Changelog       support.StagedChangelog
 	AuthToken       string
 	ProviderName    string
 	HasRequirements bool
@@ -307,7 +307,7 @@ func buildLocalUpgradeScript(params localUpgradeParams) string {
 	writeDockerfileUpdate(&sb)
 
 	// Changelog update
-	writeChangelogUpdate(&sb)
+	sb.WriteString(support.ChangelogUpdateScript())
 
 	return sb.String()
 }
@@ -356,48 +356,6 @@ func buildLocalEnv(params localUpgradeParams) []string {
 			"GIT_HTTPS_TOKEN="+params.AuthToken,
 		)
 	}
-	if params.ChangelogFile != "" {
-		env = append(env, "CHANGELOG_FILE="+params.ChangelogFile)
-	}
+	env = append(env, params.Changelog.Env()...)
 	return env
-}
-
-// prepareLocalChangelog reads CHANGELOG.md from disk (if it exists),
-// inserts an upgrade entry, and writes the result to a temp file.
-func prepareLocalChangelog(repoDir string, vCtx *versionContext) string {
-	content, err := os.ReadFile(filepath.Join(repoDir, "CHANGELOG.md"))
-	if err != nil {
-		return "" // no changelog present
-	}
-
-	var entry string
-	if vCtx.NeedsVersionUpgrade {
-		entry = fmt.Sprintf(
-			"- changed the Python version to `%s` and updated all pip dependencies",
-			vCtx.LatestVersion,
-		)
-	} else {
-		entry = "- changed the Python dependencies to their latest versions"
-	}
-
-	modified := entities.InsertChangelogEntry(string(content), []string{entry})
-	if modified == string(content) {
-		return ""
-	}
-
-	tmpFile, writeErr := os.CreateTemp("", "autoupdate-changelog-*.md")
-	if writeErr != nil {
-		logger.Warnf("[python] Failed to create temp changelog file: %v", writeErr)
-		return ""
-	}
-
-	if _, writeErr = tmpFile.WriteString(modified); writeErr != nil {
-		_ = tmpFile.Close()
-		_ = os.Remove(tmpFile.Name())
-		logger.Warnf("[python] Failed to write temp changelog: %v", writeErr)
-		return ""
-	}
-	_ = tmpFile.Close()
-
-	return tmpFile.Name()
 }

--- a/internal/infrastructure/repositories/python/python_updater_repository.go
+++ b/internal/infrastructure/repositories/python/python_updater_repository.go
@@ -153,10 +153,8 @@ func cloneAndUpgrade(
 	repo entities.Repository,
 	vCtx *versionContext,
 ) (*upgradeResult, error) {
-	changelogFile := prepareChangelog(ctx, provider, repo, vCtx)
-	if changelogFile != "" {
-		defer os.Remove(changelogFile)
-	}
+	changelog := support.StageRemoteChangelog(ctx, provider, repo, changelogEntries(vCtx))
+	defer changelog.Remove()
 	hasRequirements := provider.HasFile(ctx, repo, "requirements.txt")
 	hasPyproject := provider.HasFile(ctx, repo, "pyproject.toml")
 	hasPDM := hasPyproject && hasPDMRemote(ctx, provider, repo)
@@ -176,7 +174,7 @@ func cloneAndUpgrade(
 		PythonVersion:   vCtx.LatestVersion,
 		AuthToken:       provider.AuthToken(),
 		ProviderName:    provider.Name(),
-		ChangelogFile:   changelogFile,
+		Changelog:       changelog,
 		HasRequirements: hasRequirements,
 		HasPyproject:    hasPyproject,
 		HasPDM:          hasPDM,
@@ -299,7 +297,7 @@ func (u *UpdaterRepository) ApplyUpdates(
 		return nil, repositories.ErrNoUpdatesNeeded
 	}
 
-	// Update CHANGELOG locally
+	// Record the upgrade in the repository's changelog.
 	var entry string
 	if pyVersionUpdated {
 		entry = fmt.Sprintf(
@@ -357,13 +355,15 @@ type versionContext struct {
 }
 
 type upgradeParams struct {
-	CloneURL        string
-	DefaultBranch   string
-	BranchName      string
-	PythonVersion   string
-	AuthToken       string
-	ProviderName    string
-	ChangelogFile   string
+	CloneURL      string
+	DefaultBranch string
+	BranchName    string
+	PythonVersion string
+	AuthToken     string
+	ProviderName  string
+	// Changelog is the staged changelog payload the script copies into
+	// the clone; an empty value leaves the repository's changelog untouched.
+	Changelog       support.StagedChangelog
 	HasRequirements bool
 	HasPyproject    bool
 	HasPDM          bool
@@ -521,55 +521,17 @@ func resolveVersionContext(
 	}
 }
 
-// prepareChangelog reads the target repo's CHANGELOG.md (if it exists),
-// inserts an entry describing the Python upgrade, and writes the modified
-// content to a temp file.
-func prepareChangelog(
-	ctx context.Context,
-	provider repositories.ProviderRepository,
-	repo entities.Repository,
-	vCtx *versionContext,
-) string {
-	if !provider.HasFile(ctx, repo, "CHANGELOG.md") {
-		return ""
-	}
-
-	content, err := provider.GetFileContent(ctx, repo, "CHANGELOG.md")
-	if err != nil {
-		logger.Warnf("[python] Failed to read CHANGELOG.md: %v", err)
-		return ""
-	}
-
-	var entry string
+// changelogEntries renders the Keep a Changelog bullet describing the
+// upgrade. The staging helpers turn it into a chlog fragment when the
+// target repository uses that format instead.
+func changelogEntries(vCtx *versionContext) []string {
 	if vCtx.NeedsVersionUpgrade {
-		entry = fmt.Sprintf(
+		return []string{fmt.Sprintf(
 			"- changed the Python version to `%s` and updated all pip dependencies",
 			vCtx.LatestVersion,
-		)
-	} else {
-		entry = pyChangelogEntryDeps
+		)}
 	}
-
-	modified := entities.InsertChangelogEntry(content, []string{entry})
-	if modified == content {
-		return ""
-	}
-
-	tmpFile, writeErr := os.CreateTemp("", "autoupdate-changelog-*.md")
-	if writeErr != nil {
-		logger.Warnf("[python] Failed to create temp changelog file: %v", writeErr)
-		return ""
-	}
-
-	if _, writeErr = tmpFile.WriteString(modified); writeErr != nil {
-		_ = tmpFile.Close()
-		_ = os.Remove(tmpFile.Name())
-		logger.Warnf("[python] Failed to write temp changelog: %v", writeErr)
-		return ""
-	}
-	_ = tmpFile.Close()
-
-	return tmpFile.Name()
+	return []string{pyChangelogEntryDeps}
 }
 
 // --- clone + upgrade ---
@@ -653,8 +615,9 @@ func buildUpgradeScript(
 	// Update Dockerfile python image tags
 	writeDockerfileUpdate(&sb)
 
-	// Overwrite CHANGELOG.md with the pre-generated content (if provided)
-	writeChangelogUpdate(&sb)
+	// Copy in the staged changelog: an edited CHANGELOG.md, or a chlog
+	// fragment when the target repository uses that format.
+	sb.WriteString(support.ChangelogUpdateScript())
 
 	// Check for changes and commit/push
 	writeCommitAndPush(&sb)
@@ -818,18 +781,6 @@ func writeDockerfileUpdate(sb *strings.Builder) {
 	sb.WriteString("fi\n\n")
 }
 
-func writeChangelogUpdate(sb *strings.Builder) {
-	sb.WriteString("# Update CHANGELOG.md only if the upgrade produced actual changes.\n")
-	sb.WriteString("if [ -n \"${CHANGELOG_FILE:-}\" ] && [ -f \"$CHANGELOG_FILE\" ]; then\n")
-	sb.WriteString("    if [ -n \"$(git status --porcelain)\" ]; then\n")
-	sb.WriteString("        echo \"Updating CHANGELOG.md...\"\n")
-	sb.WriteString("        cp \"$CHANGELOG_FILE\" CHANGELOG.md\n")
-	sb.WriteString("    else\n")
-	sb.WriteString("        echo \"No dependency changes detected, skipping CHANGELOG update.\"\n")
-	sb.WriteString("    fi\n")
-	sb.WriteString("fi\n\n")
-}
-
 func writeCommitAndPush(sb *strings.Builder) {
 	sb.WriteString("if [ -n \"$(git status --porcelain)\" ]; then\n")
 	sb.WriteString("    echo \"Changes detected, committing and pushing...\"\n")
@@ -862,9 +813,7 @@ func buildEnv(params upgradeParams, repoDir string) []string {
 	if params.PythonVersion != "" {
 		env = append(env, "PYTHON_VERSION="+params.PythonVersion)
 	}
-	if params.ChangelogFile != "" {
-		env = append(env, "CHANGELOG_FILE="+params.ChangelogFile)
-	}
+	env = append(env, params.Changelog.Env()...)
 	return env
 }
 

--- a/internal/infrastructure/repositories/python/python_updater_repository_test.go
+++ b/internal/infrastructure/repositories/python/python_updater_repository_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rios0rios0/autoupdate/internal/domain/entities"
 	"github.com/rios0rios0/autoupdate/internal/infrastructure/repositories/cmdrunner"
 	pyUpdater "github.com/rios0rios0/autoupdate/internal/infrastructure/repositories/python"
+	"github.com/rios0rios0/autoupdate/internal/support"
 	"github.com/rios0rios0/autoupdate/test/infrastructure/repositorydoubles"
 )
 
@@ -359,7 +360,7 @@ func TestBuildUpgradeScript(t *testing.T) {
 			PythonVersion:   "3.13.1",
 			AuthToken:       "tok123",
 			ProviderName:    "github",
-			ChangelogFile:   "/tmp/changelog.md",
+			Changelog:       support.StagedChangelog{TempPath: "/tmp/changelog.md", RepoPath: "CHANGELOG.md"},
 			HasRequirements: true,
 			HasPyproject:    true,
 			PythonBinary:    "/usr/bin/python3",
@@ -645,7 +646,7 @@ func TestBuildEnv(t *testing.T) {
 			AuthToken:     "tok123",
 			PythonBinary:  "/usr/bin/python3",
 			PythonVersion: "3.13.1",
-			ChangelogFile: "/tmp/changelog.md",
+			Changelog:     support.StagedChangelog{TempPath: "/tmp/changelog.md", RepoPath: "CHANGELOG.md"},
 		}
 		repoDir := "/tmp/repo"
 
@@ -676,7 +677,7 @@ func TestBuildEnv(t *testing.T) {
 			AuthToken:     "tok",
 			PythonBinary:  "/usr/bin/python3",
 			PythonVersion: "",
-			ChangelogFile: "",
+			Changelog:     support.StagedChangelog{},
 		}
 
 		// when
@@ -691,100 +692,35 @@ func TestBuildEnv(t *testing.T) {
 	})
 }
 
-func TestPrepareChangelog(t *testing.T) {
+func TestChangelogEntries(t *testing.T) {
 	t.Parallel()
 
-	t.Run("should return empty string when no CHANGELOG.md exists", func(t *testing.T) {
+	t.Run("should describe the version upgrade when one is needed", func(t *testing.T) {
 		t.Parallel()
 
 		// given
-		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
-			WithExistingFiles(map[string]bool{}).
-			BuildSpy()
-		repo := entities.Repository{Organization: "org", Name: "repo"}
-		vCtx := &pyUpdater.VersionContext{
-			LatestVersion:       "3.13.1",
-			NeedsVersionUpgrade: false,
-			BranchName:          "chore/upgrade-python-deps",
-		}
+		vCtx := &pyUpdater.VersionContext{LatestVersion: "3.13.1", NeedsVersionUpgrade: true}
 
 		// when
-		result := pyUpdater.PrepareChangelog(t.Context(), provider, repo, vCtx)
+		entries := pyUpdater.ChangelogEntries(vCtx)
 
 		// then
-		assert.Equal(t, "", result)
+		assert.Equal(t, []string{
+			"- changed the Python version to `3.13.1` and updated all pip dependencies",
+		}, entries)
 	})
 
-	t.Run("should return empty string when GetFileContent fails", func(t *testing.T) {
+	t.Run("should describe only the dependencies when no version upgrade is needed", func(t *testing.T) {
 		t.Parallel()
 
 		// given
-		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
-			WithExistingFiles(map[string]bool{"CHANGELOG.md": true}).
-			WithFileContentErr(errors.New("read error")).
-			BuildSpy()
-		repo := entities.Repository{Organization: "org", Name: "repo"}
-		vCtx := &pyUpdater.VersionContext{
-			LatestVersion:       "3.13.1",
-			NeedsVersionUpgrade: false,
-			BranchName:          "chore/upgrade-python-deps",
-		}
+		vCtx := &pyUpdater.VersionContext{LatestVersion: "3.13.1", NeedsVersionUpgrade: false}
 
 		// when
-		result := pyUpdater.PrepareChangelog(t.Context(), provider, repo, vCtx)
+		entries := pyUpdater.ChangelogEntries(vCtx)
 
 		// then
-		assert.Equal(t, "", result)
-	})
-
-	t.Run("should create temp file with version upgrade entry when version upgrade needed", func(t *testing.T) {
-		t.Parallel()
-
-		// given
-		changelogContent := "# Changelog\n\n## [Unreleased]\n\n## [1.0.0] - 2025-01-01\n"
-		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
-			WithExistingFiles(map[string]bool{"CHANGELOG.md": true}).
-			WithFileContents(map[string]string{
-				"CHANGELOG.md": changelogContent,
-			}).
-			BuildSpy()
-		repo := entities.Repository{Organization: "org", Name: "repo"}
-		vCtx := &pyUpdater.VersionContext{
-			LatestVersion:       "3.13.1",
-			NeedsVersionUpgrade: true,
-			BranchName:          "chore/upgrade-python-3.13.1",
-		}
-
-		// when
-		result := pyUpdater.PrepareChangelog(t.Context(), provider, repo, vCtx)
-
-		// then
-		assert.NotEmpty(t, result)
-	})
-
-	t.Run("should create temp file with deps entry when no version upgrade needed", func(t *testing.T) {
-		t.Parallel()
-
-		// given
-		changelogContent := "# Changelog\n\n## [Unreleased]\n\n## [1.0.0] - 2025-01-01\n"
-		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
-			WithExistingFiles(map[string]bool{"CHANGELOG.md": true}).
-			WithFileContents(map[string]string{
-				"CHANGELOG.md": changelogContent,
-			}).
-			BuildSpy()
-		repo := entities.Repository{Organization: "org", Name: "repo"}
-		vCtx := &pyUpdater.VersionContext{
-			LatestVersion:       "3.13.1",
-			NeedsVersionUpgrade: false,
-			BranchName:          "chore/upgrade-python-deps",
-		}
-
-		// when
-		result := pyUpdater.PrepareChangelog(t.Context(), provider, repo, vCtx)
-
-		// then
-		assert.NotEmpty(t, result)
+		assert.Equal(t, []string{"- changed the Python dependencies to their latest versions"}, entries)
 	})
 }
 
@@ -1189,7 +1125,7 @@ func TestBuildLocalEnv(t *testing.T) {
 			PythonVersion: "3.13.1",
 			AuthToken:     "tok",
 			PythonBinary:  "/usr/bin/python3",
-			ChangelogFile: "/tmp/cl.md",
+			Changelog:     support.StagedChangelog{TempPath: "/tmp/cl.md", RepoPath: "CHANGELOG.md"},
 		}
 
 		// when
@@ -1269,70 +1205,6 @@ func TestHandleDryRun(t *testing.T) {
 		assert.Equal(t, "chore/upgrade-python-deps", result.BranchName)
 		assert.False(t, result.PythonVersionUpdated)
 		assert.False(t, result.HasChanges)
-	})
-}
-
-func TestPrepareLocalChangelog(t *testing.T) {
-	t.Parallel()
-
-	t.Run("should return empty when no CHANGELOG.md exists in directory", func(t *testing.T) {
-		t.Parallel()
-
-		// given
-		tmpDir := t.TempDir()
-		vCtx := &pyUpdater.VersionContext{
-			LatestVersion:       "3.13.1",
-			NeedsVersionUpgrade: false,
-			BranchName:          "chore/upgrade-python-deps",
-		}
-
-		// when
-		result := pyUpdater.PrepareLocalChangelog(tmpDir, vCtx)
-
-		// then
-		assert.Equal(t, "", result)
-	})
-
-	t.Run("should create temp file with deps entry when CHANGELOG exists", func(t *testing.T) {
-		t.Parallel()
-
-		// given
-		tmpDir := t.TempDir()
-		changelogPath := tmpDir + "/CHANGELOG.md"
-		changelogContent := "# Changelog\n\n## [Unreleased]\n\n## [1.0.0] - 2025-01-01\n"
-		require.NoError(t, writeTestFile(changelogPath, changelogContent))
-		vCtx := &pyUpdater.VersionContext{
-			LatestVersion:       "3.13.1",
-			NeedsVersionUpgrade: false,
-			BranchName:          "chore/upgrade-python-deps",
-		}
-
-		// when
-		result := pyUpdater.PrepareLocalChangelog(tmpDir, vCtx)
-
-		// then
-		assert.NotEmpty(t, result)
-	})
-
-	t.Run("should create temp file with version entry when upgrade is needed", func(t *testing.T) {
-		t.Parallel()
-
-		// given
-		tmpDir := t.TempDir()
-		changelogPath := tmpDir + "/CHANGELOG.md"
-		changelogContent := "# Changelog\n\n## [Unreleased]\n\n## [1.0.0] - 2025-01-01\n"
-		require.NoError(t, writeTestFile(changelogPath, changelogContent))
-		vCtx := &pyUpdater.VersionContext{
-			LatestVersion:       "3.13.1",
-			NeedsVersionUpgrade: true,
-			BranchName:          "chore/upgrade-python-3.13.1",
-		}
-
-		// when
-		result := pyUpdater.PrepareLocalChangelog(tmpDir, vCtx)
-
-		// then
-		assert.NotEmpty(t, result)
 	})
 }
 

--- a/internal/infrastructure/repositories/ruby/export_test.go
+++ b/internal/infrastructure/repositories/ruby/export_test.go
@@ -85,14 +85,9 @@ func BuildEnv(params UpgradeParamsExported, repoDir string) []string {
 	return buildEnv(params, repoDir)
 }
 
-// PrepareChangelog is exported for testing.
-func PrepareChangelog(
-	ctx context.Context,
-	provider repositories.ProviderRepository,
-	repo entities.Repository,
-	vCtx *VersionContext,
-) string {
-	return prepareChangelog(ctx, provider, repo, vCtx)
+// ChangelogEntries is exported for testing.
+func ChangelogEntries(vCtx *VersionContext) []string {
+	return changelogEntries(vCtx)
 }
 
 // LogDryRun is exported for testing.
@@ -117,11 +112,6 @@ func WriteDockerfileUpdate(sb *strings.Builder) {
 	writeDockerfileUpdate(sb)
 }
 
-// WriteChangelogUpdate is exported for testing.
-func WriteChangelogUpdate(sb *strings.Builder) {
-	writeChangelogUpdate(sb)
-}
-
 // WriteCommitAndPush is exported for testing.
 func WriteCommitAndPush(sb *strings.Builder) {
 	writeCommitAndPush(sb)
@@ -140,11 +130,6 @@ func WriteLocalAuth(sb *strings.Builder, params LocalUpgradeParamsExported) {
 // HandleDryRun is exported for testing.
 func HandleDryRun(vCtx *VersionContext, repoDir string) *LocalResult {
 	return handleDryRun(vCtx, repoDir)
-}
-
-// PrepareLocalChangelog is exported for testing.
-func PrepareLocalChangelog(repoDir string, vCtx *VersionContext) string {
-	return prepareLocalChangelog(repoDir, vCtx)
 }
 
 // SetLocalCmdRunner overrides the package-level local command runner for testing.

--- a/internal/infrastructure/repositories/ruby/local.go
+++ b/internal/infrastructure/repositories/ruby/local.go
@@ -10,9 +10,9 @@ import (
 
 	logger "github.com/sirupsen/logrus"
 
-	"github.com/rios0rios0/autoupdate/internal/domain/entities"
 	"github.com/rios0rios0/autoupdate/internal/infrastructure/repositories/cmdrunner"
 	"github.com/rios0rios0/autoupdate/internal/infrastructure/repositories/gitlocal"
+	"github.com/rios0rios0/autoupdate/internal/support"
 )
 
 // localCmdRunner is the package-level command runner for local-mode upgrade scripts.
@@ -194,17 +194,15 @@ func runLanguageUpgradeScript(
 	vCtx *versionContext,
 	opts LocalUpgradeOptions,
 ) (string, error) {
-	changelogFile := prepareLocalChangelog(repoDir, vCtx)
-	if changelogFile != "" {
-		defer os.Remove(changelogFile)
-	}
+	changelog := support.StageLocalChangelog(repoDir, changelogEntries(vCtx))
+	defer changelog.Remove()
 
 	params := localUpgradeParams{
-		BranchName:    vCtx.BranchName,
-		RubyVersion:   vCtx.LatestVersion,
-		ChangelogFile: changelogFile,
-		AuthToken:     opts.AuthToken,
-		ProviderName:  opts.ProviderName,
+		BranchName:   vCtx.BranchName,
+		RubyVersion:  vCtx.LatestVersion,
+		Changelog:    changelog,
+		AuthToken:    opts.AuthToken,
+		ProviderName: opts.ProviderName,
 	}
 
 	script := buildLocalUpgradeScript(params)
@@ -246,11 +244,13 @@ func runLanguageUpgradeScript(
 // --- local-mode internal types & helpers ---
 
 type localUpgradeParams struct {
-	BranchName    string
-	RubyVersion   string
-	ChangelogFile string
-	AuthToken     string
-	ProviderName  string
+	BranchName  string
+	RubyVersion string
+	// Changelog is the staged changelog payload the script copies into
+	// the clone; an empty value leaves the repository's changelog untouched.
+	Changelog    support.StagedChangelog
+	AuthToken    string
+	ProviderName string
 }
 
 // buildLocalUpgradeScript builds a bash script that performs only the
@@ -274,7 +274,7 @@ func buildLocalUpgradeScript(params localUpgradeParams) string {
 	writeDockerfileUpdate(&sb)
 
 	// Changelog update
-	writeChangelogUpdate(&sb)
+	sb.WriteString(support.ChangelogUpdateScript())
 
 	return sb.String()
 }
@@ -322,48 +322,6 @@ func buildLocalEnv(params localUpgradeParams) []string {
 			"GIT_HTTPS_TOKEN="+params.AuthToken,
 		)
 	}
-	if params.ChangelogFile != "" {
-		env = append(env, "CHANGELOG_FILE="+params.ChangelogFile)
-	}
+	env = append(env, params.Changelog.Env()...)
 	return env
-}
-
-// prepareLocalChangelog reads CHANGELOG.md from disk (if it exists),
-// inserts an upgrade entry, and writes the result to a temp file.
-func prepareLocalChangelog(repoDir string, vCtx *versionContext) string {
-	content, err := os.ReadFile(filepath.Join(repoDir, "CHANGELOG.md"))
-	if err != nil {
-		return "" // no changelog present
-	}
-
-	var entry string
-	if vCtx.NeedsVersionUpgrade {
-		entry = fmt.Sprintf(
-			"- changed the Ruby version to `%s` and updated all gem dependencies",
-			vCtx.LatestVersion,
-		)
-	} else {
-		entry = "- changed the Ruby gem dependencies to their latest versions"
-	}
-
-	modified := entities.InsertChangelogEntry(string(content), []string{entry})
-	if modified == string(content) {
-		return ""
-	}
-
-	tmpFile, writeErr := os.CreateTemp("", "autoupdate-changelog-*.md")
-	if writeErr != nil {
-		logger.Warnf("[ruby] Failed to create temp changelog file: %v", writeErr)
-		return ""
-	}
-
-	if _, writeErr = tmpFile.WriteString(modified); writeErr != nil {
-		_ = tmpFile.Close()
-		_ = os.Remove(tmpFile.Name())
-		logger.Warnf("[ruby] Failed to write temp changelog: %v", writeErr)
-		return ""
-	}
-	_ = tmpFile.Close()
-
-	return tmpFile.Name()
 }

--- a/internal/infrastructure/repositories/ruby/ruby_updater_repository.go
+++ b/internal/infrastructure/repositories/ruby/ruby_updater_repository.go
@@ -146,10 +146,8 @@ func cloneAndUpgrade(
 	repo entities.Repository,
 	vCtx *versionContext,
 ) (*upgradeResult, error) {
-	changelogFile := prepareChangelog(ctx, provider, repo, vCtx)
-	if changelogFile != "" {
-		defer os.Remove(changelogFile)
-	}
+	changelog := support.StageRemoteChangelog(ctx, provider, repo, changelogEntries(vCtx))
+	defer changelog.Remove()
 
 	cloneURL := provider.CloneURL(repo)
 	defaultBranch := strings.TrimPrefix(repo.DefaultBranch, "refs/heads/")
@@ -161,7 +159,7 @@ func cloneAndUpgrade(
 		RubyVersion:   vCtx.LatestVersion,
 		AuthToken:     provider.AuthToken(),
 		ProviderName:  provider.Name(),
-		ChangelogFile: changelogFile,
+		Changelog:     changelog,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to upgrade: %w", err)
@@ -261,7 +259,7 @@ func (u *UpdaterRepository) ApplyUpdates(
 		return nil, repositories.ErrNoUpdatesNeeded
 	}
 
-	// Update CHANGELOG locally
+	// Record the upgrade in the repository's changelog.
 	var entry string
 	if rbVersionUpdated {
 		entry = fmt.Sprintf(
@@ -320,7 +318,9 @@ type upgradeParams struct {
 	RubyVersion   string
 	AuthToken     string
 	ProviderName  string
-	ChangelogFile string
+	// Changelog is the staged changelog payload the script copies into
+	// the clone; an empty value leaves the repository's changelog untouched.
+	Changelog support.StagedChangelog
 }
 
 type upgradeResult struct {
@@ -377,55 +377,17 @@ func resolveVersionContext(
 	}
 }
 
-// prepareChangelog reads the target repo's CHANGELOG.md (if it exists),
-// inserts an entry describing the Ruby upgrade, and writes the modified
-// content to a temp file.
-func prepareChangelog(
-	ctx context.Context,
-	provider repositories.ProviderRepository,
-	repo entities.Repository,
-	vCtx *versionContext,
-) string {
-	if !provider.HasFile(ctx, repo, "CHANGELOG.md") {
-		return ""
-	}
-
-	content, err := provider.GetFileContent(ctx, repo, "CHANGELOG.md")
-	if err != nil {
-		logger.Warnf("[ruby] Failed to read CHANGELOG.md: %v", err)
-		return ""
-	}
-
-	var entry string
+// changelogEntries renders the Keep a Changelog bullet describing the
+// upgrade. The staging helpers turn it into a chlog fragment when the
+// target repository uses that format instead.
+func changelogEntries(vCtx *versionContext) []string {
 	if vCtx.NeedsVersionUpgrade {
-		entry = fmt.Sprintf(
+		return []string{fmt.Sprintf(
 			"- changed the Ruby version to `%s` and updated all gem dependencies",
 			vCtx.LatestVersion,
-		)
-	} else {
-		entry = rbChangelogEntryDeps
+		)}
 	}
-
-	modified := entities.InsertChangelogEntry(content, []string{entry})
-	if modified == content {
-		return ""
-	}
-
-	tmpFile, writeErr := os.CreateTemp("", "autoupdate-changelog-*.md")
-	if writeErr != nil {
-		logger.Warnf("[ruby] Failed to create temp changelog file: %v", writeErr)
-		return ""
-	}
-
-	if _, writeErr = tmpFile.WriteString(modified); writeErr != nil {
-		_ = tmpFile.Close()
-		_ = os.Remove(tmpFile.Name())
-		logger.Warnf("[ruby] Failed to write temp changelog: %v", writeErr)
-		return ""
-	}
-	_ = tmpFile.Close()
-
-	return tmpFile.Name()
+	return []string{rbChangelogEntryDeps}
 }
 
 // --- clone + upgrade ---
@@ -507,8 +469,9 @@ func buildUpgradeScript(
 	// Update Dockerfile ruby image tags
 	writeDockerfileUpdate(&sb)
 
-	// Overwrite CHANGELOG.md with the pre-generated content (if provided)
-	writeChangelogUpdate(&sb)
+	// Copy in the staged changelog: an edited CHANGELOG.md, or a chlog
+	// fragment when the target repository uses that format.
+	sb.WriteString(support.ChangelogUpdateScript())
 
 	// Check for changes and commit/push
 	writeCommitAndPush(&sb)
@@ -591,18 +554,6 @@ func writeDockerfileUpdate(sb *strings.Builder) {
 	sb.WriteString("fi\n\n")
 }
 
-func writeChangelogUpdate(sb *strings.Builder) {
-	sb.WriteString("# Update CHANGELOG.md only if the upgrade produced actual changes.\n")
-	sb.WriteString("if [ -n \"${CHANGELOG_FILE:-}\" ] && [ -f \"$CHANGELOG_FILE\" ]; then\n")
-	sb.WriteString("    if [ -n \"$(git status --porcelain)\" ]; then\n")
-	sb.WriteString("        echo \"Updating CHANGELOG.md...\"\n")
-	sb.WriteString("        cp \"$CHANGELOG_FILE\" CHANGELOG.md\n")
-	sb.WriteString("    else\n")
-	sb.WriteString("        echo \"No dependency changes detected, skipping CHANGELOG update.\"\n")
-	sb.WriteString("    fi\n")
-	sb.WriteString("fi\n\n")
-}
-
 func writeCommitAndPush(sb *strings.Builder) {
 	sb.WriteString("if [ -n \"$(git status --porcelain)\" ]; then\n")
 	sb.WriteString("    echo \"Changes detected, committing and pushing...\"\n")
@@ -634,9 +585,7 @@ func buildEnv(params upgradeParams, repoDir string) []string {
 	if params.RubyVersion != "" {
 		env = append(env, "TARGET_RUBY_VERSION="+params.RubyVersion)
 	}
-	if params.ChangelogFile != "" {
-		env = append(env, "CHANGELOG_FILE="+params.ChangelogFile)
-	}
+	env = append(env, params.Changelog.Env()...)
 	return env
 }
 

--- a/internal/infrastructure/repositories/terraform/terraform_updater_repository.go
+++ b/internal/infrastructure/repositories/terraform/terraform_updater_repository.go
@@ -144,18 +144,7 @@ func (u *UpdaterRepository) ApplyUpdates(
 		return nil, err
 	}
 
-	entries := make([]string, 0, len(upgrades))
-	for _, up := range upgrades {
-		label := "Terraform module"
-		if up.kind == depKindImage {
-			label = "container image"
-		}
-		entries = append(entries, fmt.Sprintf(
-			"- changed the %s `%s` from `%s` to `%s`",
-			label, extractRepoName(up.dep.Source), up.dep.CurrentVer, up.newVersion,
-		))
-	}
-	support.LocalChangelogUpdate(repoDir, entries)
+	support.LocalChangelogUpdate(repoDir, changelogEntries(upgrades))
 
 	return &repositories.LocalUpdateResult{
 		BranchName:    generateBranchName(upgrades),
@@ -843,9 +832,10 @@ func generatePRTitle(tasks []upgradeTask) string {
 	)
 }
 
-// appendChangelogEntry reads the target repo's CHANGELOG.md (if it exists),
-// inserts entries describing the Terraform module upgrades, and appends the
-// modified file to the change set.
+// appendChangelogEntry records the Terraform module upgrades in the target
+// repo's changelog and appends the resulting file to the change set. The
+// format -- Keep a Changelog or chlog fragments -- is decided by the shared
+// helper from what the repository itself commits.
 func appendChangelogEntry(
 	ctx context.Context,
 	provider repositories.ProviderRepository,
@@ -853,16 +843,12 @@ func appendChangelogEntry(
 	upgrades []upgradeTask,
 	fileChanges []entities.FileChange,
 ) []entities.FileChange {
-	if !provider.HasFile(ctx, repo, "CHANGELOG.md") {
-		return fileChanges
-	}
+	return support.RemoteChangelogChanges(
+		ctx, provider, repo, changelogEntries(upgrades), fileChanges)
+}
 
-	content, err := provider.GetFileContent(ctx, repo, "CHANGELOG.md")
-	if err != nil {
-		logger.Warnf("[terraform] Failed to read CHANGELOG.md: %v", err)
-		return fileChanges
-	}
-
+// changelogEntries renders one Keep a Changelog bullet per upgrade.
+func changelogEntries(upgrades []upgradeTask) []string {
 	entries := make([]string, 0, len(upgrades))
 	for _, up := range upgrades {
 		label := "Terraform module"
@@ -874,17 +860,7 @@ func appendChangelogEntry(
 			label, extractRepoName(up.dep.Source), up.dep.CurrentVer, up.newVersion,
 		))
 	}
-
-	modified := entities.InsertChangelogEntry(content, entries)
-	if modified == content {
-		return fileChanges
-	}
-
-	return append(fileChanges, entities.FileChange{
-		Path:       "CHANGELOG.md",
-		Content:    modified,
-		ChangeType: "edit",
-	})
+	return entries
 }
 
 func generatePRDescription(tasks []upgradeTask) string {

--- a/internal/support/changelog.go
+++ b/internal/support/changelog.go
@@ -1,0 +1,410 @@
+package support
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	logger "github.com/sirupsen/logrus"
+
+	"github.com/rios0rios0/autoupdate/internal/domain/entities"
+	"github.com/rios0rios0/autoupdate/internal/domain/repositories"
+)
+
+// ChangelogFileName is the Keep a Changelog document autoupdate appends to when
+// a repository does not use chlog.
+const ChangelogFileName = "CHANGELOG.md"
+
+// StagedChangelog is a changelog payload staged in a temporary file, waiting to
+// be copied into a cloned repository by a generated upgrade script.
+//
+// The script-driven updaters (Go, Python, JavaScript, Ruby, Java, C#) do the
+// clone themselves, so they cannot write the file directly; they hand the pair
+// to bash through the CHANGELOG_FILE and CHANGELOG_DEST environment variables.
+// Carrying the destination alongside the content is what lets the same script
+// serve both formats: a Keep a Changelog run copies to CHANGELOG.md, a chlog
+// run copies to .changes/unreleased/<fragment>.yaml.
+type StagedChangelog struct {
+	// TempPath is the host path holding the content, or "" when there is
+	// nothing to write.
+	TempPath string
+	// RepoPath is the repository-relative destination, using forward slashes.
+	RepoPath string
+	// Fragment reports whether RepoPath is a new chlog fragment rather than an
+	// edit of an existing changelog. It decides how an abandoned run is cleaned
+	// up: git restores an edited file, but a created one has to be deleted.
+	Fragment bool
+}
+
+// IsEmpty reports whether nothing was staged, in which case the script must not
+// touch the changelog at all.
+func (s StagedChangelog) IsEmpty() bool {
+	return s.TempPath == ""
+}
+
+// Remove deletes the temporary file. It is safe to call on an empty result.
+func (s StagedChangelog) Remove() {
+	if s.TempPath != "" {
+		_ = os.Remove(s.TempPath)
+	}
+}
+
+// Discard removes the copy the script placed in repoDir, for a run the caller
+// decided to abandon.
+//
+// Only a chlog fragment needs it: an edited CHANGELOG.md is a tracked file that
+// the caller's "git checkout" restores, whereas a fragment is a new untracked
+// file that would survive the checkout and be left behind in the repository.
+func (s StagedChangelog) Discard(repoDir string) {
+	if s.IsEmpty() || !s.Fragment {
+		return
+	}
+
+	path := entities.ChlogFragmentDiskPath(repoDir, s.RepoPath)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		logger.Warnf("Failed to discard the chlog fragment %s: %v", path, err)
+	}
+}
+
+// Env returns the environment entries ChangelogUpdateScript reads. An empty
+// result contributes nothing, which leaves CHANGELOG_FILE unset and makes the
+// script skip the copy.
+func (s StagedChangelog) Env() []string {
+	if s.IsEmpty() {
+		return nil
+	}
+	return []string{
+		"CHANGELOG_FILE=" + s.TempPath,
+		"CHANGELOG_DEST=" + s.RepoPath,
+	}
+}
+
+// ChangelogUpdateScript is the bash fragment that copies a staged changelog
+// into the repository the upgrade script has cloned.
+//
+// The destination comes from the environment rather than being hard-coded, so
+// the same fragment serves both formats: a Keep a Changelog run copies over
+// CHANGELOG.md, a chlog run creates a new file under the unreleased directory.
+// The copy is skipped when the upgrade produced no other change, which is what
+// prevents pull requests that only touch the changelog.
+func ChangelogUpdateScript() string {
+	return `# Update the changelog only if the upgrade produced actual changes.
+# This prevents creating empty PRs that only touch the changelog.
+if [ -n "${CHANGELOG_FILE:-}" ] && [ -f "$CHANGELOG_FILE" ]; then
+    if [ -n "$(git status --porcelain)" ]; then
+        CHANGELOG_DEST="${CHANGELOG_DEST:-` + ChangelogFileName + `}"
+        echo "Updating $CHANGELOG_DEST..."
+        mkdir -p "$(dirname "$CHANGELOG_DEST")"
+        cp "$CHANGELOG_FILE" "$CHANGELOG_DEST"
+    else
+        echo "No dependency changes detected, skipping the changelog update."
+    fi
+fi
+
+`
+}
+
+// LocalChangelogUpdate records the given Keep a Changelog bullet entries in a
+// repository on disk. Returns true when a file was written.
+//
+// A repository using chlog gets one fragment per entry under its unreleased
+// directory; every other repository gets the entries inserted into the
+// [Unreleased] section of CHANGELOG.md, as before.
+func LocalChangelogUpdate(repoDir string, entries []string) bool {
+	if len(entries) == 0 {
+		return false
+	}
+
+	config, usesChlog, err := DetectLocalChlog(repoDir)
+	if err != nil {
+		logger.Warnf("Failed to detect chlog in %s, leaving the changelog untouched: %v", repoDir, err)
+		return false
+	}
+	if usesChlog {
+		return writeLocalChlogFragments(repoDir, config, entries)
+	}
+
+	return insertLocalChangelogEntries(repoDir, entries)
+}
+
+// writeLocalChlogFragments renders the entries as chlog fragments and writes
+// them under the repository's unreleased directory, creating it when a
+// .chlog.yaml declares a directory that does not exist yet.
+func writeLocalChlogFragments(
+	repoDir string,
+	config *entities.ChlogConfig,
+	entries []string,
+) bool {
+	fragments, err := config.NewChlogFragments(entries, time.Now())
+	if err != nil {
+		logger.Warnf("Failed to build the chlog fragments: %v", err)
+		return false
+	}
+	if len(fragments) == 0 {
+		return false
+	}
+
+	unreleasedDir := entities.ChlogFragmentDiskPath(repoDir, config.UnreleasedPath())
+	// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+	if err = os.MkdirAll(unreleasedDir, entities.ChlogFragmentDirMode); err != nil {
+		logger.Warnf("Failed to create the chlog fragment directory %s: %v", unreleasedDir, err)
+		return false
+	}
+
+	written := false
+	for _, fragment := range fragments {
+		fragmentPath := entities.ChlogFragmentDiskPath(repoDir, fragment.Path)
+
+		// path is validated against escaping the repository root
+		if err = os.WriteFile(fragmentPath, []byte(fragment.Content), 0o600); err != nil {
+			logger.Warnf("Failed to write the chlog fragment %s: %v", fragmentPath, err)
+			continue
+		}
+		written = true
+	}
+
+	if written {
+		logger.Infof("Recorded %d chlog fragment(s) in %s", len(fragments), config.UnreleasedPath())
+	}
+	return written
+}
+
+// insertLocalChangelogEntries appends the entries to the [Unreleased] section of
+// CHANGELOG.md on disk. A repository without a changelog is left alone.
+func insertLocalChangelogEntries(repoDir string, entries []string) bool {
+	changelogPath := filepath.Clean(filepath.Join(repoDir, ChangelogFileName))
+	data, err := os.ReadFile(changelogPath)
+	if err != nil {
+		logger.Warnf("Failed to read %s: %v", ChangelogFileName, err)
+		return false
+	}
+
+	content := string(data)
+	modified := entities.InsertChangelogEntry(content, entries)
+	if modified == content {
+		return false
+	}
+
+	writeErr := os.WriteFile( //nolint:gosec // repoDir is a controlled internal path
+		changelogPath,
+		[]byte(modified),
+		0o600,
+	)
+	if writeErr != nil {
+		logger.Warnf("Failed to write %s: %v", ChangelogFileName, writeErr)
+		return false
+	}
+	return true
+}
+
+// RemoteChangelogChanges builds the file changes that record the given entries
+// in a repository reachable through the provider API, appending them to the
+// change set the caller is assembling.
+//
+// A repository using chlog gets one added fragment per entry; every other
+// repository gets an edited CHANGELOG.md. A repository with neither chlog nor a
+// changelog gets nothing, leaving the change set untouched.
+func RemoteChangelogChanges(
+	ctx context.Context,
+	provider repositories.ProviderRepository,
+	repo entities.Repository,
+	entries []string,
+	fileChanges []entities.FileChange,
+) []entities.FileChange {
+	if len(entries) == 0 {
+		return fileChanges
+	}
+
+	config, usesChlog, err := DetectRemoteChlog(ctx, provider, repo)
+	if err != nil {
+		logger.Warnf("Failed to detect chlog in %s, leaving the changelog untouched: %v",
+			entities.RepoKey(repo), err)
+		return fileChanges
+	}
+
+	if usesChlog {
+		fragments, fragErr := config.NewChlogFragments(entries, time.Now())
+		if fragErr != nil {
+			logger.Warnf("Failed to build the chlog fragments: %v", fragErr)
+			return fileChanges
+		}
+		return append(fileChanges, fragments...)
+	}
+
+	change, ok := remoteChangelogEdit(ctx, provider, repo, entries)
+	if !ok {
+		return fileChanges
+	}
+	return append(fileChanges, change)
+}
+
+// remoteChangelogEdit fetches CHANGELOG.md through the provider and returns the
+// edited file. The boolean is false when the repository has no changelog, the
+// fetch fails, or the insertion changed nothing.
+func remoteChangelogEdit(
+	ctx context.Context,
+	provider repositories.ProviderRepository,
+	repo entities.Repository,
+	entries []string,
+) (entities.FileChange, bool) {
+	if !provider.HasFile(ctx, repo, ChangelogFileName) {
+		return entities.FileChange{}, false
+	}
+
+	content, err := provider.GetFileContent(ctx, repo, ChangelogFileName)
+	if err != nil {
+		logger.Warnf("Failed to read %s: %v", ChangelogFileName, err)
+		return entities.FileChange{}, false
+	}
+
+	modified := entities.InsertChangelogEntry(content, entries)
+	if modified == content {
+		return entities.FileChange{}, false
+	}
+
+	return entities.FileChange{
+		Path:       ChangelogFileName,
+		Content:    modified,
+		ChangeType: "edit",
+	}, true
+}
+
+// StageLocalChangelog prepares the changelog payload for a repository on disk
+// without writing it into the repository, for the updaters whose upgrade runs
+// through a generated script that performs the copy itself.
+//
+// The caller must Remove the result once the script has run.
+func StageLocalChangelog(repoDir string, entries []string) StagedChangelog {
+	if len(entries) == 0 {
+		return StagedChangelog{}
+	}
+
+	config, usesChlog, err := DetectLocalChlog(repoDir)
+	if err != nil {
+		logger.Warnf("Failed to detect chlog in %s, leaving the changelog untouched: %v", repoDir, err)
+		return StagedChangelog{}
+	}
+	if usesChlog {
+		return stageChlogFragment(config, entries)
+	}
+
+	content, err := os.ReadFile(filepath.Join(repoDir, ChangelogFileName))
+	if err != nil {
+		return StagedChangelog{} // no changelog present
+	}
+	return stageChangelogEdit(string(content), entries)
+}
+
+// StageRemoteChangelog is StageLocalChangelog for a repository that has not been
+// cloned yet: the current content is fetched through the provider API, and the
+// generated script copies the staged file into the clone it makes itself.
+//
+// The caller must Remove the result once the script has run.
+func StageRemoteChangelog(
+	ctx context.Context,
+	provider repositories.ProviderRepository,
+	repo entities.Repository,
+	entries []string,
+) StagedChangelog {
+	if len(entries) == 0 {
+		return StagedChangelog{}
+	}
+
+	config, usesChlog, err := DetectRemoteChlog(ctx, provider, repo)
+	if err != nil {
+		logger.Warnf("Failed to detect chlog in %s, leaving the changelog untouched: %v",
+			entities.RepoKey(repo), err)
+		return StagedChangelog{}
+	}
+	if usesChlog {
+		return stageChlogFragment(config, entries)
+	}
+
+	if !provider.HasFile(ctx, repo, ChangelogFileName) {
+		return StagedChangelog{}
+	}
+
+	content, err := provider.GetFileContent(ctx, repo, ChangelogFileName)
+	if err != nil {
+		logger.Warnf("Failed to read %s: %v", ChangelogFileName, err)
+		return StagedChangelog{}
+	}
+	return stageChangelogEdit(content, entries)
+}
+
+// stageChlogFragment writes the entries to a temporary fragment file.
+//
+// The script copies exactly one file, so the entries are merged into a single
+// fragment. Every script-driven updater passes a single entry anyway -- the
+// per-dependency wording belongs to the updaters that build the change set
+// themselves -- so nothing is lost, and a multi-line body is what chlog renders
+// as one bullet with its continuation lines.
+func stageChlogFragment(config *entities.ChlogConfig, entries []string) StagedChangelog {
+	fragments, err := config.NewChlogFragments([]string{joinChangelogEntries(entries)}, time.Now())
+	if err != nil {
+		logger.Warnf("Failed to build the chlog fragment: %v", err)
+		return StagedChangelog{}
+	}
+	if len(fragments) == 0 {
+		return StagedChangelog{}
+	}
+
+	tempPath, err := writeTempChangelog(fragments[0].Content, "autoupdate-chlog-*.yaml")
+	if err != nil {
+		logger.Warnf("Failed to stage the chlog fragment: %v", err)
+		return StagedChangelog{}
+	}
+
+	return StagedChangelog{TempPath: tempPath, RepoPath: fragments[0].Path, Fragment: true}
+}
+
+// stageChangelogEdit writes the edited CHANGELOG.md to a temporary file. An
+// insertion that changed nothing stages nothing, so the script does not produce
+// a commit that only rewrites the changelog identically.
+func stageChangelogEdit(content string, entries []string) StagedChangelog {
+	modified := entities.InsertChangelogEntry(content, entries)
+	if modified == content {
+		return StagedChangelog{}
+	}
+
+	tempPath, err := writeTempChangelog(modified, "autoupdate-changelog-*.md")
+	if err != nil {
+		logger.Warnf("Failed to stage %s: %v", ChangelogFileName, err)
+		return StagedChangelog{}
+	}
+
+	return StagedChangelog{TempPath: tempPath, RepoPath: ChangelogFileName}
+}
+
+// joinChangelogEntries collapses multiple bullets into one fragment body,
+// keeping each on its own line so chlog renders them as a bullet with nested
+// continuation lines.
+func joinChangelogEntries(entries []string) string {
+	bodies := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if body := entities.StripBulletPrefix(entry); body != "" {
+			bodies = append(bodies, body)
+		}
+	}
+	return strings.Join(bodies, "\n")
+}
+
+// writeTempChangelog writes content to a new temporary file and returns its path.
+func writeTempChangelog(content, pattern string) (string, error) {
+	file, err := os.CreateTemp("", pattern)
+	if err != nil {
+		return "", fmt.Errorf("failed to create the temporary file: %w", err)
+	}
+
+	if _, err = file.WriteString(content); err != nil {
+		_ = file.Close()
+		_ = os.Remove(file.Name())
+		return "", fmt.Errorf("failed to write the temporary file: %w", err)
+	}
+	_ = file.Close()
+
+	return file.Name(), nil
+}

--- a/internal/support/changelog_test.go
+++ b/internal/support/changelog_test.go
@@ -1,0 +1,421 @@
+//go:build unit
+
+package support_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/rios0rios0/autoupdate/internal/domain/entities"
+	"github.com/rios0rios0/autoupdate/internal/support"
+	"github.com/rios0rios0/autoupdate/test/infrastructure/repositorydoubles"
+)
+
+const baseChangelog = "# Changelog\n\n## [Unreleased]\n\n## [1.0.0] - 2026-01-01\n"
+
+func TestLocalChangelogUpdateWithChlog(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should write a fragment instead of touching CHANGELOG.md", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		root := writeChlogRepo(t, map[string]string{
+			".chlog.yaml":  "changesDir: .changes\n",
+			"CHANGELOG.md": baseChangelog,
+		})
+
+		// when
+		updated := support.LocalChangelogUpdate(root,
+			[]string{"- changed the Go module dependencies to their latest versions"})
+
+		// then
+		assert.True(t, updated)
+
+		fragments := readChlogFragments(t, root, ".changes/unreleased")
+		require.Len(t, fragments, 1)
+
+		var fragment entities.ChlogFragment
+		require.NoError(t, yaml.Unmarshal([]byte(fragments[0]), &fragment))
+		assert.Equal(t, "Changed", fragment.Kind)
+		assert.Equal(t, "changed the Go module dependencies to their latest versions", fragment.Body)
+
+		changelog, err := os.ReadFile(filepath.Join(root, "CHANGELOG.md"))
+		require.NoError(t, err)
+		assert.Equal(t, baseChangelog, string(changelog),
+			"the changelog chlog compiles into must be left untouched")
+	})
+
+	t.Run("should write one fragment per entry", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		root := writeChlogRepo(t, map[string]string{".changes/unreleased/": ""})
+
+		// when
+		updated := support.LocalChangelogUpdate(root, []string{
+			"- changed the Docker base image `alpine` from `3.19` to `3.20`",
+			"- changed the Docker base image `golang` from `1.24` to `1.25`",
+		})
+
+		// then
+		assert.True(t, updated)
+		assert.Len(t, readChlogFragments(t, root, ".changes/unreleased"), 2)
+	})
+
+	t.Run("should create the unreleased directory the configuration declares", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		root := writeChlogRepo(t, map[string]string{
+			".chlog.yaml": "changesDir: docs/changes\nunreleasedDir: pending\n",
+		})
+
+		// when
+		updated := support.LocalChangelogUpdate(root, []string{"- changed a dependency"})
+
+		// then
+		assert.True(t, updated)
+		assert.Len(t, readChlogFragments(t, root, "docs/changes/pending"), 1)
+	})
+
+	t.Run("should leave the repository untouched when the configuration is broken", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		root := writeChlogRepo(t, map[string]string{
+			".chlog.yaml":  "changesDir: ../../etc\n",
+			"CHANGELOG.md": baseChangelog,
+		})
+
+		// when
+		updated := support.LocalChangelogUpdate(root, []string{"- changed a dependency"})
+
+		// then
+		assert.False(t, updated)
+
+		changelog, err := os.ReadFile(filepath.Join(root, "CHANGELOG.md"))
+		require.NoError(t, err)
+		assert.Equal(t, baseChangelog, string(changelog))
+	})
+
+	t.Run("should still edit CHANGELOG.md when the repository does not use chlog", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		root := writeChlogRepo(t, map[string]string{"CHANGELOG.md": baseChangelog})
+
+		// when
+		updated := support.LocalChangelogUpdate(root, []string{"- changed a dependency"})
+
+		// then
+		assert.True(t, updated)
+
+		changelog, err := os.ReadFile(filepath.Join(root, "CHANGELOG.md"))
+		require.NoError(t, err)
+		assert.Contains(t, string(changelog), "- changed a dependency")
+	})
+
+	t.Run("should do nothing when there are no entries", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		root := writeChlogRepo(t, map[string]string{".changes/unreleased/": ""})
+
+		// when
+		updated := support.LocalChangelogUpdate(root, nil)
+
+		// then
+		assert.False(t, updated)
+		assert.Empty(t, readChlogFragments(t, root, ".changes/unreleased"))
+	})
+}
+
+func TestRemoteChangelogChanges(t *testing.T) {
+	t.Parallel()
+
+	repo := entities.Repository{Organization: "org", Name: "repo"}
+
+	t.Run("should add a fragment per entry when the repository uses chlog", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{".chlog.yaml": true, "CHANGELOG.md": true}).
+			WithFileContents(map[string]string{
+				".chlog.yaml":  "changesDir: .changes\n",
+				"CHANGELOG.md": baseChangelog,
+			}).
+			BuildSpy()
+		entries := []string{"- changed dependency `a`", "- changed dependency `b`"}
+
+		// when
+		changes := support.RemoteChangelogChanges(t.Context(), provider, repo, entries, nil)
+
+		// then
+		require.Len(t, changes, 2)
+		for _, change := range changes {
+			assert.Equal(t, "add", change.ChangeType)
+			assert.True(t, strings.HasPrefix(change.Path, ".changes/unreleased/"), change.Path)
+			assert.NotContains(t, change.Path, "CHANGELOG.md")
+		}
+	})
+
+	t.Run("should edit CHANGELOG.md when the repository does not use chlog", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{"CHANGELOG.md": true}).
+			WithFileContents(map[string]string{"CHANGELOG.md": baseChangelog}).
+			BuildSpy()
+
+		// when
+		changes := support.RemoteChangelogChanges(
+			t.Context(), provider, repo, []string{"- changed dependency `a`"}, nil)
+
+		// then
+		require.Len(t, changes, 1)
+		assert.Equal(t, "CHANGELOG.md", changes[0].Path)
+		assert.Equal(t, "edit", changes[0].ChangeType)
+		assert.Contains(t, changes[0].Content, "- changed dependency `a`")
+	})
+
+	t.Run("should keep the existing changes when the repository has no changelog", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{}).
+			BuildSpy()
+		existing := []entities.FileChange{{Path: "go.mod", ChangeType: "edit"}}
+
+		// when
+		changes := support.RemoteChangelogChanges(
+			t.Context(), provider, repo, []string{"- changed dependency `a`"}, existing)
+
+		// then
+		assert.Equal(t, existing, changes)
+	})
+
+	t.Run("should keep the existing changes when detection fails", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{".chlog.yaml": true}).
+			WithFileContents(map[string]string{".chlog.yaml": "changesDir: /etc\n"}).
+			BuildSpy()
+		existing := []entities.FileChange{{Path: "go.mod", ChangeType: "edit"}}
+
+		// when
+		changes := support.RemoteChangelogChanges(
+			t.Context(), provider, repo, []string{"- changed dependency `a`"}, existing)
+
+		// then
+		assert.Equal(t, existing, changes)
+	})
+}
+
+func TestStageLocalChangelog(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should stage a fragment aimed at the unreleased directory", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		root := writeChlogRepo(t, map[string]string{".chlog.yaml": "changesDir: .changes\n"})
+
+		// when
+		staged := support.StageLocalChangelog(root, []string{"- changed a dependency"})
+		defer staged.Remove()
+
+		// then
+		require.False(t, staged.IsEmpty())
+		assert.True(t, strings.HasPrefix(staged.RepoPath, ".changes/unreleased/"), staged.RepoPath)
+
+		content, err := os.ReadFile(staged.TempPath)
+		require.NoError(t, err)
+
+		var fragment entities.ChlogFragment
+		require.NoError(t, yaml.Unmarshal(content, &fragment))
+		assert.Equal(t, "Changed", fragment.Kind)
+		assert.Equal(t, "changed a dependency", fragment.Body)
+	})
+
+	t.Run("should merge several entries into one fragment body", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		root := writeChlogRepo(t, map[string]string{".changes/unreleased/": ""})
+
+		// when
+		staged := support.StageLocalChangelog(root, []string{"- changed `a`", "- changed `b`"})
+		defer staged.Remove()
+
+		// then
+		require.False(t, staged.IsEmpty())
+
+		content, err := os.ReadFile(staged.TempPath)
+		require.NoError(t, err)
+
+		var fragment entities.ChlogFragment
+		require.NoError(t, yaml.Unmarshal(content, &fragment))
+		assert.Equal(t, "changed `a`\nchanged `b`", fragment.Body)
+	})
+
+	t.Run("should stage the edited CHANGELOG.md when the repository does not use chlog", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		root := writeChlogRepo(t, map[string]string{"CHANGELOG.md": baseChangelog})
+
+		// when
+		staged := support.StageLocalChangelog(root, []string{"- changed a dependency"})
+		defer staged.Remove()
+
+		// then
+		require.False(t, staged.IsEmpty())
+		assert.Equal(t, "CHANGELOG.md", staged.RepoPath)
+
+		content, err := os.ReadFile(staged.TempPath)
+		require.NoError(t, err)
+		assert.Contains(t, string(content), "- changed a dependency")
+	})
+
+	t.Run("should stage nothing when the repository has neither chlog nor a changelog", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		root := writeChlogRepo(t, map[string]string{"go.mod": "module example\n"})
+
+		// when
+		staged := support.StageLocalChangelog(root, []string{"- changed a dependency"})
+
+		// then
+		assert.True(t, staged.IsEmpty())
+		assert.Empty(t, staged.Env())
+	})
+}
+
+func TestStageRemoteChangelog(t *testing.T) {
+	t.Parallel()
+
+	repo := entities.Repository{Organization: "org", Name: "repo"}
+
+	t.Run("should stage a fragment when the repository uses chlog", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{".chlog.yaml": true}).
+			WithFileContents(map[string]string{".chlog.yaml": "unreleasedDir: pending\n"}).
+			BuildSpy()
+
+		// when
+		staged := support.StageRemoteChangelog(
+			t.Context(), provider, repo, []string{"- changed a dependency"})
+		defer staged.Remove()
+
+		// then
+		require.False(t, staged.IsEmpty())
+		assert.True(t, strings.HasPrefix(staged.RepoPath, ".changes/pending/"), staged.RepoPath)
+		assert.Equal(t, []string{
+			"CHANGELOG_FILE=" + staged.TempPath,
+			"CHANGELOG_DEST=" + staged.RepoPath,
+		}, staged.Env())
+	})
+
+	t.Run("should stage the edited CHANGELOG.md when the repository does not use chlog", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{"CHANGELOG.md": true}).
+			WithFileContents(map[string]string{"CHANGELOG.md": baseChangelog}).
+			BuildSpy()
+
+		// when
+		staged := support.StageRemoteChangelog(
+			t.Context(), provider, repo, []string{"- changed a dependency"})
+		defer staged.Remove()
+
+		// then
+		require.False(t, staged.IsEmpty())
+		assert.Equal(t, "CHANGELOG.md", staged.RepoPath)
+	})
+
+	t.Run("should stage nothing when the repository has no changelog", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{}).
+			BuildSpy()
+
+		// when
+		staged := support.StageRemoteChangelog(
+			t.Context(), provider, repo, []string{"- changed a dependency"})
+
+		// then
+		assert.True(t, staged.IsEmpty())
+	})
+
+	t.Run("should stage nothing when fetching the changelog fails", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{"CHANGELOG.md": true}).
+			WithFileContentErr(assert.AnError).
+			BuildSpy()
+
+		// when
+		staged := support.StageRemoteChangelog(
+			t.Context(), provider, repo, []string{"- changed a dependency"})
+
+		// then
+		assert.True(t, staged.IsEmpty())
+	})
+}
+
+func TestChangelogUpdateScript(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should copy the staged file to the destination the environment names", func(t *testing.T) {
+		t.Parallel()
+
+		// given / when
+		script := support.ChangelogUpdateScript()
+
+		// then
+		assert.Contains(t, script, `cp "$CHANGELOG_FILE" "$CHANGELOG_DEST"`)
+		assert.Contains(t, script, `mkdir -p "$(dirname "$CHANGELOG_DEST")"`)
+	})
+
+	t.Run("should default the destination to CHANGELOG.md", func(t *testing.T) {
+		t.Parallel()
+
+		// given / when
+		script := support.ChangelogUpdateScript()
+
+		// then
+		assert.Contains(t, script, `CHANGELOG_DEST="${CHANGELOG_DEST:-CHANGELOG.md}"`)
+	})
+
+	t.Run("should skip the copy when the upgrade produced no other change", func(t *testing.T) {
+		t.Parallel()
+
+		// given / when
+		script := support.ChangelogUpdateScript()
+
+		// then
+		assert.Contains(t, script, "git status --porcelain")
+	})
+}

--- a/internal/support/chlog.go
+++ b/internal/support/chlog.go
@@ -72,7 +72,7 @@ func loadLocalChlogConfig(repoDir string) (*entities.ChlogConfig, bool, error) {
 
 		config, err := entities.ParseChlogConfig(data)
 		if err != nil {
-			return nil, false, err
+			return nil, false, fmt.Errorf("%s: %w", configPath, err)
 		}
 		return config, true, nil
 	}
@@ -105,7 +105,7 @@ func DetectRemoteChlog(
 
 		config, err := entities.ParseChlogConfig([]byte(content))
 		if err != nil {
-			return nil, false, err
+			return nil, false, fmt.Errorf("%s in %s: %w", name, entities.RepoKey(repo), err)
 		}
 		return config, true, nil
 	}

--- a/internal/support/chlog.go
+++ b/internal/support/chlog.go
@@ -1,0 +1,163 @@
+package support
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/rios0rios0/autoupdate/internal/domain/entities"
+	"github.com/rios0rios0/autoupdate/internal/domain/repositories"
+)
+
+// chlogFragmentExtensions are the suffixes a pending fragment can carry. chlog
+// writes ".yaml"; ".yml" is accepted so a hand-written fragment still counts as
+// evidence that the repository uses the tool.
+//
+//nolint:gochecknoglobals // read-only lookup table
+var chlogFragmentExtensions = []string{".yaml", ".yml"}
+
+// DetectLocalChlog reports whether a repository on disk uses chlog and returns
+// the effective configuration.
+//
+// A repository counts as a chlog user when it commits a .chlog.yaml or when the
+// unreleased fragment directory exists -- the configuration file is optional.
+// Unlike chlog itself, the search never walks above repoDir: autoupdate is
+// strictly per-repository, and a .chlog.yaml in a parent directory says nothing
+// about this repo.
+//
+// A malformed or unreadable configuration is reported as an error rather than
+// as "not a chlog repository": falling back would make autoupdate edit the
+// CHANGELOG.md that chlog exists to keep untouched.
+func DetectLocalChlog(repoDir string) (*entities.ChlogConfig, bool, error) {
+	config, hasConfigFile, err := loadLocalChlogConfig(repoDir)
+	if err != nil {
+		return nil, false, err
+	}
+	if hasConfigFile {
+		return config, true, nil
+	}
+
+	unreleasedDir := entities.ChlogFragmentDiskPath(repoDir, config.UnreleasedPath())
+	info, err := os.Stat(unreleasedDir)
+	switch {
+	case err == nil:
+		return config, info.IsDir(), nil
+	case errors.Is(err, os.ErrNotExist):
+		return config, false, nil
+	default:
+		// A stat failure other than "absent" -- a permission error, a broken
+		// mount -- must not be read as "this project does not use chlog": that
+		// would silently write the entry into the wrong file.
+		return nil, false, fmt.Errorf(
+			"failed to inspect the chlog fragment directory %s: %w", unreleasedDir, err)
+	}
+}
+
+// loadLocalChlogConfig reads .chlog.yaml (or .chlog.yml) from the repository
+// root. The boolean reports whether a file was found.
+func loadLocalChlogConfig(repoDir string) (*entities.ChlogConfig, bool, error) {
+	for _, name := range []string{entities.ChlogConfigFile, entities.ChlogAltConfigFile} {
+		configPath := filepath.Join(repoDir, name)
+
+		data, err := os.ReadFile(configPath)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to read %s: %w", configPath, err)
+		}
+
+		config, err := entities.ParseChlogConfig(data)
+		if err != nil {
+			return nil, false, err
+		}
+		return config, true, nil
+	}
+
+	defaults := entities.DefaultChlogConfig()
+	return &defaults, false, nil
+}
+
+// DetectRemoteChlog reports whether a repository reachable through the provider
+// API uses chlog and returns the effective configuration.
+//
+// It mirrors DetectLocalChlog, trading the two stat calls for one HasFile probe
+// per configuration file name plus, only when neither is present, a single tree
+// listing to look for pending fragments.
+func DetectRemoteChlog(
+	ctx context.Context,
+	provider repositories.ProviderRepository,
+	repo entities.Repository,
+) (*entities.ChlogConfig, bool, error) {
+	for _, name := range []string{entities.ChlogConfigFile, entities.ChlogAltConfigFile} {
+		if !provider.HasFile(ctx, repo, name) {
+			continue
+		}
+
+		content, err := provider.GetFileContent(ctx, repo, name)
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to fetch %s for %s: %w",
+				name, entities.RepoKey(repo), err)
+		}
+
+		config, err := entities.ParseChlogConfig([]byte(content))
+		if err != nil {
+			return nil, false, err
+		}
+		return config, true, nil
+	}
+
+	defaults := entities.DefaultChlogConfig()
+	hasFragments, err := hasRemoteChlogFragments(ctx, provider, repo, &defaults)
+	if err != nil {
+		return nil, false, err
+	}
+	return &defaults, hasFragments, nil
+}
+
+// hasRemoteChlogFragments reports whether the repository carries any pending
+// fragment.
+//
+// ListFiles only filters on a path suffix, and every provider fetches the whole
+// tree regardless of the pattern, so the listing is requested once unfiltered
+// and both the directory prefix and the extension are matched here. That keeps
+// the probe to a single API call while still recognising either extension.
+func hasRemoteChlogFragments(
+	ctx context.Context,
+	provider repositories.ProviderRepository,
+	repo entities.Repository,
+	config *entities.ChlogConfig,
+) (bool, error) {
+	files, err := provider.ListFiles(ctx, repo, "")
+	if err != nil {
+		return false, fmt.Errorf("failed to list the files of %s: %w", entities.RepoKey(repo), err)
+	}
+
+	prefix := config.UnreleasedPath() + "/"
+	for _, file := range files {
+		if file.IsDir {
+			continue
+		}
+		// Azure DevOps returns tree paths rooted at "/", the other providers
+		// return them relative to the repository root.
+		path := strings.TrimPrefix(file.Path, "/")
+		if strings.HasPrefix(path, prefix) && hasChlogFragmentExtension(path) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// hasChlogFragmentExtension reports whether a path carries a fragment suffix.
+func hasChlogFragmentExtension(path string) bool {
+	for _, ext := range chlogFragmentExtensions {
+		if strings.HasSuffix(path, ext) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/support/chlog_test.go
+++ b/internal/support/chlog_test.go
@@ -143,6 +143,22 @@ func TestDetectLocalChlog(t *testing.T) {
 		// then
 		require.Error(t, err)
 		assert.False(t, usesChlog)
+		assert.Contains(t, err.Error(), ".chlog.yaml")
+	})
+
+	t.Run("should name the .chlog.yml file it actually read in a parse error", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		root := writeChlogRepo(t, map[string]string{".chlog.yml": "kinds: [oops\n"})
+
+		// when
+		_, _, err := support.DetectLocalChlog(root)
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), ".chlog.yml")
+		assert.NotContains(t, err.Error(), ".chlog.yaml")
 	})
 }
 

--- a/internal/support/chlog_test.go
+++ b/internal/support/chlog_test.go
@@ -1,0 +1,279 @@
+//go:build unit
+
+package support_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rios0rios0/autoupdate/internal/domain/entities"
+	"github.com/rios0rios0/autoupdate/internal/support"
+	"github.com/rios0rios0/autoupdate/test/infrastructure/repositorydoubles"
+)
+
+// writeChlogRepo lays out a repository on disk with the given files, where a
+// path ending in "/" creates a directory.
+func writeChlogRepo(t *testing.T, files map[string]string) string {
+	t.Helper()
+
+	root := t.TempDir()
+	for path, content := range files {
+		full := filepath.Join(root, filepath.FromSlash(path))
+		if content == "" && path[len(path)-1] == '/' {
+			// A directory needs the owner search bit, so 0o700 is the
+			// least-privilege mode here.
+			// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+			require.NoError(t, os.MkdirAll(full, 0o700))
+			continue
+		}
+		// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o700))
+		require.NoError(t, os.WriteFile(full, []byte(content), 0o600))
+	}
+	return root
+}
+
+// readChlogFragments returns the fragment files pending under dir.
+func readChlogFragments(t *testing.T, root, dir string) []string {
+	t.Helper()
+
+	entries, err := os.ReadDir(filepath.Join(root, filepath.FromSlash(dir)))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	require.NoError(t, err)
+
+	contents := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		data, readErr := os.ReadFile(filepath.Join(root, filepath.FromSlash(dir), entry.Name()))
+		require.NoError(t, readErr)
+		contents = append(contents, string(data))
+	}
+	return contents
+}
+
+func TestDetectLocalChlog(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should detect chlog when the repository commits a .chlog.yaml", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		root := writeChlogRepo(t, map[string]string{".chlog.yaml": "changesDir: .changes\n"})
+
+		// when
+		config, usesChlog, err := support.DetectLocalChlog(root)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, usesChlog)
+		assert.Equal(t, ".changes/unreleased", config.UnreleasedPath())
+	})
+
+	t.Run("should detect chlog from the .chlog.yml spelling", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		root := writeChlogRepo(t, map[string]string{".chlog.yml": "unreleasedDir: pending\n"})
+
+		// when
+		config, usesChlog, err := support.DetectLocalChlog(root)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, usesChlog)
+		assert.Equal(t, ".changes/pending", config.UnreleasedPath())
+	})
+
+	t.Run("should detect chlog from the unreleased directory alone", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		root := writeChlogRepo(t, map[string]string{".changes/unreleased/": ""})
+
+		// when
+		_, usesChlog, err := support.DetectLocalChlog(root)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, usesChlog)
+	})
+
+	t.Run("should not detect chlog for a plain Keep a Changelog repository", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		root := writeChlogRepo(t, map[string]string{"CHANGELOG.md": "# Changelog\n"})
+
+		// when
+		_, usesChlog, err := support.DetectLocalChlog(root)
+
+		// then
+		require.NoError(t, err)
+		assert.False(t, usesChlog)
+	})
+
+	t.Run("should return an error when the configuration escapes the repository", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		root := writeChlogRepo(t, map[string]string{".chlog.yaml": "changesDir: ../../etc\n"})
+
+		// when
+		_, usesChlog, err := support.DetectLocalChlog(root)
+
+		// then
+		require.ErrorIs(t, err, entities.ErrChlogPathEscapesRepo)
+		assert.False(t, usesChlog)
+	})
+
+	t.Run("should return an error when the configuration is not valid YAML", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		root := writeChlogRepo(t, map[string]string{".chlog.yaml": "kinds: [oops\n"})
+
+		// when
+		_, usesChlog, err := support.DetectLocalChlog(root)
+
+		// then
+		require.Error(t, err)
+		assert.False(t, usesChlog)
+	})
+}
+
+func TestDetectRemoteChlog(t *testing.T) {
+	t.Parallel()
+
+	repo := entities.Repository{Organization: "org", Name: "repo"}
+
+	t.Run("should detect chlog when the repository commits a .chlog.yaml", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{".chlog.yaml": true}).
+			WithFileContents(map[string]string{".chlog.yaml": "unreleasedDir: pending\n"}).
+			BuildSpy()
+
+		// when
+		config, usesChlog, err := support.DetectRemoteChlog(t.Context(), provider, repo)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, usesChlog)
+		assert.Equal(t, ".changes/pending", config.UnreleasedPath())
+	})
+
+	t.Run("should detect chlog from a pending fragment alone", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{}).
+			WithFiles([]entities.File{
+				{Path: "README.md"},
+				{Path: ".changes/unreleased/1748359200-a1b2.yaml"},
+			}).
+			BuildSpy()
+
+		// when
+		_, usesChlog, err := support.DetectRemoteChlog(t.Context(), provider, repo)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, usesChlog)
+	})
+
+	t.Run("should detect chlog from an Azure DevOps root-anchored path", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{}).
+			WithFiles([]entities.File{{Path: "/.changes/unreleased/1748359200-a1b2.yaml"}}).
+			BuildSpy()
+
+		// when
+		_, usesChlog, err := support.DetectRemoteChlog(t.Context(), provider, repo)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, usesChlog)
+	})
+
+	t.Run("should not detect chlog for a plain Keep a Changelog repository", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{"CHANGELOG.md": true}).
+			WithFiles([]entities.File{{Path: "CHANGELOG.md"}, {Path: "go.mod"}}).
+			BuildSpy()
+
+		// when
+		_, usesChlog, err := support.DetectRemoteChlog(t.Context(), provider, repo)
+
+		// then
+		require.NoError(t, err)
+		assert.False(t, usesChlog)
+	})
+
+	t.Run("should not mistake the unreleased directory entry for a fragment", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{}).
+			WithFiles([]entities.File{
+				{Path: ".changes/unreleased/notes.md"},
+				{Path: ".changes/unreleased/sub", IsDir: true},
+			}).
+			BuildSpy()
+
+		// when
+		_, usesChlog, err := support.DetectRemoteChlog(t.Context(), provider, repo)
+
+		// then
+		require.NoError(t, err)
+		assert.False(t, usesChlog)
+	})
+
+	t.Run("should return an error when the configuration cannot be fetched", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{".chlog.yaml": true}).
+			WithFileContentErr(assert.AnError).
+			BuildSpy()
+
+		// when
+		_, usesChlog, err := support.DetectRemoteChlog(t.Context(), provider, repo)
+
+		// then
+		require.Error(t, err)
+		assert.False(t, usesChlog)
+	})
+
+	t.Run("should return an error when the tree cannot be listed", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		provider := repositorydoubles.NewSpyProviderRepositoryBuilder().
+			WithExistingFiles(map[string]bool{}).
+			WithListFileErr(assert.AnError).
+			BuildSpy()
+
+		// when
+		_, usesChlog, err := support.DetectRemoteChlog(t.Context(), provider, repo)
+
+		// then
+		require.Error(t, err)
+		assert.False(t, usesChlog)
+	})
+}

--- a/internal/support/filesystem.go
+++ b/internal/support/filesystem.go
@@ -111,31 +111,3 @@ func HasUncommittedChanges(ctx context.Context, repoDir string) bool {
 	}
 	return len(strings.TrimSpace(string(output))) > 0
 }
-
-// LocalChangelogUpdate reads CHANGELOG.md from repoDir, inserts entries,
-// and writes it back if modified. Returns true if the file was updated.
-func LocalChangelogUpdate(repoDir string, entries []string) bool {
-	changelogPath := filepath.Clean(filepath.Join(repoDir, "CHANGELOG.md"))
-	data, err := os.ReadFile(changelogPath)
-	if err != nil {
-		logger.Warnf("Failed to read CHANGELOG.md: %v", err)
-		return false
-	}
-
-	content := string(data)
-	modified := entities.InsertChangelogEntry(content, entries)
-	if modified == content {
-		return false
-	}
-
-	writeErr := os.WriteFile( //nolint:gosec // repoDir is a controlled internal path
-		changelogPath,
-		[]byte(modified),
-		0o600,
-	)
-	if writeErr != nil {
-		logger.Warnf("Failed to write CHANGELOG.md: %v", writeErr)
-		return false
-	}
-	return true
-}


### PR DESCRIPTION
## Summary

[chlog](https://github.com/luizjhonata/chlog) replaces the shared `CHANGELOG.md` with one YAML file per change under `.changes/unreleased/`, which is what removes changelog merge conflicts between concurrent pull requests. Editing `[Unreleased]` in such a repository puts automated pull requests straight back into the conflicts chlog exists to remove.

AutoUpdate now detects the format and writes a fragment instead, leaving `CHANGELOG.md` untouched:

```yaml
# .changes/unreleased/1785339281801779333-551e.yaml
kind: Changed
body: changed the Go module dependencies to their latest versions
time: 2026-07-29T15:34:41Z
```

Detection is automatic — a repository counts as a chlog user when it commits a `.chlog.yaml`/`.chlog.yml` or merely carries a `.changes/unreleased/` directory, since chlog works without a config file. The declared `changesDir`, `unreleasedDir` and `kinds` are honored. Repositories that do not use chlog are unaffected.

Covers all nine ecosystems in both local and batch mode.

## Approach

The nine ecosystems each carried their own copy of the changelog logic, in three shapes: a direct disk write, a `FileChange` for the provider API, and a temp-file-plus-bash-`cp`. Rather than teach chlog to all of them, they now record their entries through one implementation in `internal/support/changelog.go`, so format detection lives in exactly one place and the two formats cannot drift apart.

The six byte-identical bash blocks became one shared snippet that takes its destination from `CHANGELOG_DEST`, which is what lets the same script write either format. Net −1233/+432 lines outside the new files; only a per-ecosystem `changelogEntries(vCtx)` remains ecosystem-specific.

`.chlog.yaml` is untrusted input — batch mode clones repositories AutoUpdate does not own — so configured paths are validated against escaping the repository root, and a broken config fails loudly rather than falling back to editing the `CHANGELOG.md` chlog exists to protect.

## Bug found and fixed along the way

The JavaScript updater reverts the working tree when a run turns out to be a cosmetic lockfile-version sync. `git checkout -- .` restores an edited `CHANGELOG.md`, but a chlog fragment is a **new untracked** file — it would have survived and been left behind in the user's own repository after AutoUpdate reported "no updates needed". `StagedChangelog.Discard` now removes it, with tests for both the fragment and the `CHANGELOG.md` case.

## Verification

- `make lint` 0 issues; `make test` all green; CodeQL 0 findings, Trivy clean, Gitleaks clean. Semgrep did not run locally — its binary is missing in this environment, unrelated to this change.
- Executed the generated bash for real against a git repository in all three cases: chlog destination, `CHANGELOG.md` default, and the no-op skip when the upgrade produced no other change.
- Round-tripped a fragment through the real `chlog` binary using chlog's own `.chlog.yaml`: `chlog check` → `batch auto` → `merge` compiled it into a correct `### Changed` section — the same section `InsertChangelogEntry` would have written to.

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?
- [x] Did you run all the code checks? (`go test`)
- [x] Are the tests passing?

🤖 Generated with [Claude Code](https://claude.com/claude-code)